### PR TITLE
Fix file path for Python result to a relative file path

### DIFF
--- a/src/features/analyzer/AnalyzerModule.tsx
+++ b/src/features/analyzer/AnalyzerModule.tsx
@@ -201,7 +201,7 @@ export function AnalyzerModule() {
       pyodide.globals.set('file_content', file.content);
       
       // Execute the Python code and get the result
-      const result = await runPythonCode(pyodide, file.content, '/scripts/pycode.py', 'process_data');
+      const result = await runPythonCode(pyodide, file.content, './scripts/pycode.py', 'process_data');
 
       // Store the processed result back in the database
       // This way users can view both original and processed versions


### PR DESCRIPTION
The original code used the file path `'\scripts\pycode.py'`

However, the initial backslash means this is an absolute path. When the code is hosted on Github Pages, the file structure changes such that the absolute path is incorrect. As such, we need to change it to a relative path; `'.\scripts\pycode.py'` should work.