### PR TITLE
feature: schema validation, dual file upload, seed input, loading screen

### DIFF
--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -1,15 +1,3 @@
-/**
- * icons.tsx
- * Location: src/components/ui/icons.tsx
- *
- * Purpose:
- *   Shared icon components used across TurtleShell stages.
- *   All icons use currentColor and accept an optional className
- *   for sizing/coloring at the call site.
- *
- *   Add new icons here — don't define them inline in stage components.
- */
-
 interface IconProps {
   className?: string;
 }
@@ -124,6 +112,20 @@ export function LoopIcon({ className = "w-3.5 h-3.5" }: IconProps) {
   return (
     <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+    </svg>
+  );
+}
+
+/** Dice icon — used for the seed randomize button in ModelConfig */
+export function DiceIcon({ className = "w-3.5 h-3.5" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <rect x="3" y="3" width="18" height="18" rx="3" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} />
+      <circle cx="8.5" cy="8.5" r="1" fill="currentColor" stroke="none" />
+      <circle cx="15.5" cy="8.5" r="1" fill="currentColor" stroke="none" />
+      <circle cx="8.5" cy="15.5" r="1" fill="currentColor" stroke="none" />
+      <circle cx="15.5" cy="15.5" r="1" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="12" r="1" fill="currentColor" stroke="none" />
     </svg>
   );
 }

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -15,4 +15,5 @@ export {
   SpinnerIcon,
   LoopIcon,
   SnapshotIcon,
+  DiceIcon,
 } from "./icons";

--- a/src/features/analyzer/MorphAnalyzer.tsx
+++ b/src/features/analyzer/MorphAnalyzer.tsx
@@ -157,7 +157,6 @@ function StageRenderer({ ts }: { ts: UseTurtleshellReturn }) {
         <TrainingProgressStage
           steps={ts.trainingSteps}
           currentIteration={ts.currentIteration}
-          totalIterations={ts.totalIterations}
           isComplete={ts.isTrainingComplete}
           onContinue={() => ts.goToStage("results")}
           onSnapshot={ts.handleDownloadSnapshot}
@@ -172,8 +171,8 @@ function StageRenderer({ ts }: { ts: UseTurtleshellReturn }) {
           onSkip={ts.handleSkipAnnotation}
           totalWords={ts.totalAnnotationWords}
           currentIteration={ts.currentIteration}
-          totalIterations={ts.totalIterations}
           onSnapshot={ts.handleDownloadSnapshot}
+          onReadSnapshot={ts.handleReadSnapshot}
         />
       );
     case "results":

--- a/src/features/analyzer/MorphAnalyzer.tsx
+++ b/src/features/analyzer/MorphAnalyzer.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { useTurtleshell, type UseTurtleshellReturn } from "../../hooks/useTurtleShell";
-import { TurtleLogo, TurtleShellBackground, StepIndicator } from "../../components/layout";
+import { TurtleShellBackground, StepIndicator } from "../../components/layout";
 import { type WorkflowStage } from "../../lib/types";
 import {
   DatasetIngestion,
@@ -15,22 +15,20 @@ import {
 export function MorphAnalyzer() {
   const ts = useTurtleshell();
 
-  // Stay on the init screen until both systems are ready, then hold for a
-  // brief moment so the user can see the "ready" state before it disappears.
-  const [initializing, setInitializing] = useState(true);
-  const [readyToTransition, setReadyToTransition] = useState(false);
-  const transitionTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [showOverlay, setShowOverlay] = useState(true);
+  const [allReady, setAllReady]       = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    if (ts.pyodideReady && ts.indexedDBReady && initializing) {
-      // Show the "all ready" state for 600ms before sliding into the app
-      setReadyToTransition(true);
-      transitionTimer.current = setTimeout(() => setInitializing(false), 700);
+    if (ts.pyodideReady && ts.indexedDBReady && !allReady) {
+      setAllReady(true);
+
+      // Unmount overlay after its fade completes.
+      // App content is already visible underneath — no separate appVisible state needed.
+      timerRef.current = setTimeout(() => setShowOverlay(false), 900);
     }
-    return () => {
-      if (transitionTimer.current) clearTimeout(transitionTimer.current);
-    };
-  }, [ts.pyodideReady, ts.indexedDBReady, initializing]);
+    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+  }, [ts.pyodideReady, ts.indexedDBReady, allReady]);
 
   return (
     <div className="min-h-screen flex items-center justify-center p-4 md:p-8 relative">
@@ -39,55 +37,49 @@ export function MorphAnalyzer() {
       <main className="w-full max-w-4xl relative z-10">
         <div className="bg-card/98 backdrop-blur-3xl border border-border/20 rounded-2xl shadow-2xl shadow-black/40 overflow-hidden ring-1 ring-white/5">
 
-          {/* Header — no status dots, they live in the init screen now */}
-          <header className="px-6 py-4 flex items-center justify-between border-b border-border/20 bg-secondary/5">
-            <div className="flex items-center gap-4">
-              <div className="w-11 h-11 rounded-xl bg-gradient-to-br from-primary/20 to-primary/5 border border-primary/10 flex items-center justify-center">
-                <TurtleLogo className="w-6 h-6 text-primary" />
+          <header className="px-6 py-4 flex items-center border-b border-border/20 bg-secondary/5">
+            <div>
+              <div className="flex items-center gap-2.5">
+                <h1 className="font-mono text-base font-semibold tracking-tight text-foreground">
+                  turtleshell
+                </h1>
+                <span className="px-1.5 py-0.5 rounded bg-secondary/30 font-mono text-[9px] text-muted-foreground/50 uppercase tracking-wider">
+                  v1.0
+                </span>
               </div>
-              <div>
-                <div className="flex items-center gap-2.5">
-                  <h1 className="font-mono text-base font-semibold tracking-tight text-foreground">
-                    turtleshell
-                  </h1>
-                  <span className="px-1.5 py-0.5 rounded bg-secondary/30 font-mono text-[9px] text-muted-foreground/50 uppercase tracking-wider">
-                    v1.0
-                  </span>
-                </div>
-                <p className="font-mono text-[10px] text-muted-foreground/50 mt-0.5">
-                  morphological segmentation
-                </p>
-              </div>
+              <p className="font-mono text-[10px] text-muted-foreground/50 mt-0.5">
+                morphological segmentation
+              </p>
             </div>
           </header>
 
-          {initializing ? (
-            <InitView
-              pyodideReady={ts.pyodideReady}
-              indexedDBReady={ts.indexedDBReady}
-              pyodideError={ts.pyodideError}
-              allReady={readyToTransition}
-            />
-          ) : (
-            <>
-              {/* Error banners — only shown post-init */}
-              {ts.pyodideError && (
+          {/* App content always rendered — overlay sits on top */}
+          <div className="relative">
+            <div>
+              {ts.pyodideError && !showOverlay && (
                 <ErrorBanner
                   message={`Pyodide failed to load: ${ts.pyodideError}`}
                   hint="Check your connection — Pyodide downloads ~10MB on first run. Private browsing may block required storage."
                 />
               )}
-
               <div className="border-b border-border/20">
                 <StepIndicator
                   currentStage={ts.currentStage}
                   completedStages={ts.completedStages}
                 />
               </div>
-
               <AnimatedStageRenderer ts={ts} />
-            </>
-          )}
+            </div>
+
+            {showOverlay && (
+              <InitOverlay
+                pyodideReady={ts.pyodideReady}
+                indexedDBReady={ts.indexedDBReady}
+                pyodideError={ts.pyodideError}
+                allReady={allReady}
+              />
+            )}
+          </div>
         </div>
 
         <p className="mt-5 text-center font-mono text-[9px] text-muted-foreground/30 tracking-wider">
@@ -98,164 +90,231 @@ export function MorphAnalyzer() {
   );
 }
 
-// ── Initialization screen ────────────────────────────────────────────────────
+// ── Loading label hook ────────────────────────────────────────────────────────
 
-interface InitViewProps {
+const TIMED_STAGES = [
+  { after: 0,     label: "Starting up" },
+  { after: 2500,  label: "Loading Python runtime" },
+  { after: 7000,  label: "Installing packages" },
+  { after: 14000, label: "Almost ready" },
+] as const;
+
+function useLoadingLabel(pyodideReady: boolean, indexedDBReady: boolean, allReady: boolean) {
+  const startRef = useRef(Date.now());
+  const [timedLabel, setTimedLabel] = useState<string>(TIMED_STAGES[0].label);
+
+  useEffect(() => {
+    if (allReady) return;
+    const id = setInterval(() => {
+      const elapsed = Date.now() - startRef.current;
+      const stage = [...TIMED_STAGES].reverse().find((s) => elapsed >= s.after);
+      if (stage) setTimedLabel(stage.label);
+    }, 500);
+    return () => clearInterval(id);
+  }, [allReady]);
+
+  if (allReady)                        return "Ready";
+  if (pyodideReady && !indexedDBReady) return "Opening database";
+  return timedLabel;
+}
+
+// ── Init overlay ─────────────────────────────────────────────────────────────
+
+const FAVICON = `${import.meta.env.BASE_URL}favicon.ico`;
+
+const ICON_SIZE = 96;
+const GAP       = 18;
+const RING_R    = ICON_SIZE / 2 + GAP;
+const STROKE_W  = 1.5;
+const CIRCUMF   = 2 * Math.PI * RING_R;
+const SVG_SIZE  = (RING_R + STROKE_W + 2) * 2;
+const C         = SVG_SIZE / 2;
+
+const ORBIT_R   = RING_R + 16;
+const ORBIT_SVG = (ORBIT_R + STROKE_W + 2) * 2;
+const OC        = ORBIT_SVG / 2;
+
+// Arc length in indeterminate mode — 35% of the ring
+const INDET_ARC = CIRCUMF * 0.35;
+
+const HINTS = [
+  "Selects the words the model is least sure about",
+  "Your corrections retrain the model each cycle",
+  "Active learning reduces labeling effort",
+  "Uncertainty sampling finds hard cases first",
+  "Each annotated word compounds model accuracy",
+];
+
+interface InitOverlayProps {
   pyodideReady: boolean;
   indexedDBReady: boolean;
   pyodideError: string | null;
   allReady: boolean;
 }
 
-function InitView({ pyodideReady, indexedDBReady, pyodideError, allReady }: InitViewProps) {
+function InitOverlay({ pyodideReady, indexedDBReady, pyodideError, allReady }: InitOverlayProps) {
+  const hasError   = !!pyodideError;
+  const readyCount = (pyodideReady ? 1 : 0) + (indexedDBReady ? 1 : 0);
+
+  // Single numeric progress value: 0 → 0.5 → 1.0
+  // We start at a small non-zero value so the arc is visible immediately —
+  // this avoids the jarring "nothing then something" at t=0.
+  const progress = hasError ? 0.3 : readyCount > 0 ? readyCount / 2 : 0;
+
+  // ── Single arc element, two modes ──────────────────────────────────────────
+  //
+  // Indeterminate (progress === 0): short arc + stroke-dashoffset animation
+  //   makes the arc travel around the ring. dasharray = "ARC GAP" so the arc
+  //   is always ARC_LENGTH long.
+  //
+  // Determinate (progress > 0): dasharray = full circumference, dashoffset
+  //   controls how much is filled. CSS transition handles the smooth fill.
+  //
+  // Because it's always the SAME <circle> element, React never unmounts it
+  // and there's no position snap between modes.
+
+  const isIndeterminate = progress === 0 && !hasError;
+
+  const arcDashArray  = isIndeterminate
+    ? `${INDET_ARC} ${CIRCUMF - INDET_ARC}`
+    : `${CIRCUMF} ${CIRCUMF}`;
+
+  const arcDashOffset = isIndeterminate
+    ? 0                                  // animation drives it
+    : CIRCUMF * (1 - progress);
+
+  const arcColor = hasError ? "rgb(248 113 113)" : "var(--color-primary, #6b8f3a)";
+
+  const arcStyle: React.CSSProperties = isIndeterminate
+    ? {
+        animation: `ts-chase ${(CIRCUMF / 140).toFixed(1)}s linear infinite`,
+        opacity: 0.7,
+      }
+    : {
+        // When transitioning OUT of indeterminate the browser will smoothly
+        // interpolate strokeDashoffset from wherever the animation left it.
+        transition: "stroke-dashoffset 900ms cubic-bezier(0, 0, 0.2, 1), stroke-dasharray 600ms ease, opacity 300ms ease",
+        opacity: 1,
+      };
+
+  // Cycling hint
+  const [hintIndex, setHintIndex]   = useState(0);
+  const [hintVisible, setHintVisible] = useState(true);
+  useEffect(() => {
+    if (allReady) return;
+    const id = setInterval(() => {
+      setHintVisible(false);
+      setTimeout(() => {
+        setHintIndex((i) => (i + 1) % HINTS.length);
+        setHintVisible(true);
+      }, 400);
+    }, 3200);
+    return () => clearInterval(id);
+  }, [allReady]);
+
+  const loadingLabel = useLoadingLabel(pyodideReady, indexedDBReady, allReady);
+
   return (
     <div
-      className="flex flex-col items-center justify-center px-8 py-16 gap-10 transition-opacity duration-500"
-      style={{ opacity: allReady ? 0 : 1 }}
+      className="absolute inset-0 flex flex-col items-center justify-center bg-card/98"
+      style={{
+        opacity: allReady ? 0 : 1,
+        pointerEvents: allReady ? "none" : "auto",
+        // Fade out. The app content is already rendered below — no blank gap.
+        transition: "opacity 700ms cubic-bezier(0.4, 0, 1, 1)",
+        minHeight: 420,
+        zIndex: 10,
+      }}
     >
-      {/* Animated logo */}
-      <div className="relative flex items-center justify-center">
-        {/* Outer ring — spins until both ready */}
-        <div
-          className={`absolute w-20 h-20 rounded-full border-2 border-t-primary border-r-primary/30 border-b-primary/10 border-l-primary/30 transition-all duration-700 ${
-            allReady ? "border-primary/40 animate-none scale-110" : "animate-spin"
-          }`}
-          style={{ animationDuration: "2s" }}
-        />
-        {/* Inner pulsing circle */}
-        <div
-          className={`w-14 h-14 rounded-2xl bg-gradient-to-br from-primary/20 to-primary/5 border border-primary/15 flex items-center justify-center transition-all duration-500 ${
-            allReady ? "scale-110 border-primary/40 from-primary/30" : "animate-pulse"
-          }`}
+      {/* Ring + icon */}
+      <div className="relative flex items-center justify-center" style={{ marginBottom: 36 }}>
+
+        {/* Outer orbit — slow dashed rotation */}
+        <svg
+          width={ORBIT_SVG} height={ORBIT_SVG}
+          viewBox={`0 0 ${ORBIT_SVG} ${ORBIT_SVG}`}
+          className="absolute"
+          style={{ animation: "ts-orbit 20s linear infinite" }}
         >
-          <TurtleLogo
-            className={`w-7 h-7 transition-colors duration-500 ${
-              allReady ? "text-primary" : "text-primary/60"
-            }`}
+          <circle
+            cx={OC} cy={OC} r={ORBIT_R}
+            fill="none" stroke="currentColor"
+            strokeWidth={0.75} strokeDasharray="2 22" strokeLinecap="round"
+            className="text-border/20"
           />
-        </div>
-      </div>
+        </svg>
 
-      {/* Status items */}
-      <div className="flex flex-col gap-3 w-full max-w-xs">
-        <InitItem
-          label="Python Runtime"
-          sublabel="Loading Pyodide + CRF library"
-          isReady={pyodideReady}
-          hasError={!!pyodideError}
-          errorMessage={pyodideError ?? undefined}
-        />
-        <InitItem
-          label="Database"
-          sublabel="Opening IndexedDB storage"
-          isReady={indexedDBReady}
-          hasError={false}
-        />
-      </div>
-
-      {/* Status text */}
-      <p
-        className={`font-mono text-[11px] tracking-wider transition-colors duration-500 ${
-          allReady
-            ? "text-primary/70"
-            : pyodideError
-              ? "text-red-400/70"
-              : "text-muted-foreground/40"
-        }`}
-      >
-        {pyodideError
-          ? "Failed to initialize — see error above"
-          : allReady
-            ? "Ready"
-            : "Initializing…"}
-      </p>
-    </div>
-  );
-}
-
-function InitItem({
-  label,
-  sublabel,
-  isReady,
-  hasError,
-  errorMessage,
-}: {
-  label: string;
-  sublabel: string;
-  isReady: boolean;
-  hasError: boolean;
-  errorMessage?: string;
-}) {
-  return (
-    <div
-      className={`flex items-center gap-4 px-4 py-3.5 rounded-xl border transition-all duration-500 ${
-        hasError
-          ? "border-red-400/20 bg-red-400/5"
-          : isReady
-            ? "border-primary/20 bg-primary/5"
-            : "border-border/10 bg-secondary/5"
-      }`}
-    >
-      {/* State icon */}
-      <div className="shrink-0 w-7 h-7 flex items-center justify-center">
-        {hasError ? (
-          <div className="w-5 h-5 rounded-full bg-red-400/15 flex items-center justify-center">
-            <span className="font-mono text-[10px] text-red-400 leading-none">✕</span>
-          </div>
-        ) : isReady ? (
-          <div className="w-5 h-5 rounded-full bg-primary/15 flex items-center justify-center">
-            {/* Checkmark svg inline — no extra icon import needed */}
-            <svg className="w-3 h-3 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
-            </svg>
-          </div>
-        ) : (
-          <svg
-            className="w-5 h-5 text-muted-foreground/30 animate-spin"
-            style={{ animationDuration: "1.2s" }}
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <circle className="opacity-20" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" />
-            <path
-              className="opacity-70"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-            />
-          </svg>
-        )}
-      </div>
-
-      {/* Label */}
-      <div className="flex-1 min-w-0">
-        <p
-          className={`font-mono text-[12px] font-medium transition-colors duration-500 ${
-            hasError
-              ? "text-red-400"
-              : isReady
-                ? "text-primary"
-                : "text-foreground/60"
-          }`}
+        {/* Progress ring — always rotated so arc starts at top */}
+        <svg
+          width={SVG_SIZE} height={SVG_SIZE}
+          viewBox={`0 0 ${SVG_SIZE} ${SVG_SIZE}`}
+          className="absolute"
+          style={{ transform: "rotate(-90deg)" }}
         >
-          {label}
-        </p>
-        <p className="font-mono text-[10px] text-muted-foreground/40 mt-0.5 truncate">
-          {hasError && errorMessage ? errorMessage : sublabel}
+          {/* Track */}
+          <circle
+            cx={C} cy={C} r={RING_R}
+            fill="none" stroke="currentColor"
+            strokeWidth={STROKE_W} className="text-border/15"
+          />
+
+          {/* Single arc — indeterminate or determinate, never remounted */}
+          <circle
+            cx={C} cy={C} r={RING_R}
+            fill="none"
+            stroke={arcColor}
+            strokeWidth={STROKE_W}
+            strokeLinecap="round"
+            strokeDasharray={arcDashArray}
+            strokeDashoffset={arcDashOffset}
+            style={arcStyle}
+          />
+        </svg>
+
+        {/* Favicon */}
+        <img
+          src={FAVICON} alt="TurtleShell"
+          width={ICON_SIZE} height={ICON_SIZE}
+          draggable={false}
+          style={{
+            position: "relative", zIndex: 1, borderRadius: 16,
+            opacity: hasError ? 0.4 : 1,
+            transition: "opacity 400ms ease",
+            userSelect: "none",
+          }}
+        />
+      </div>
+
+      {/* Status label */}
+      <div style={{ minHeight: 20, marginBottom: 18, textAlign: "center" }}>
+        <p className="font-mono text-[10px] text-muted-foreground/80 uppercase tracking-widest">
+          {hasError ? "Initialization failed" : loadingLabel}
         </p>
       </div>
 
-      {/* Ready / loading pill */}
-      <div
-        className={`shrink-0 px-2 py-0.5 rounded-md font-mono text-[9px] uppercase tracking-wider transition-all duration-500 ${
-          hasError
-            ? "bg-red-400/10 text-red-400/70"
-            : isReady
-              ? "bg-primary/10 text-primary/70"
-              : "bg-border/10 text-muted-foreground/30"
-        }`}
-      >
-        {hasError ? "error" : isReady ? "ready" : "loading"}
+      {/* Cycling hint */}
+      <div style={{ minHeight: 18, textAlign: "center", maxWidth: 280 }}>
+        <p
+          className="font-mono text-[11px] text-muted-foreground/80 text-center leading-relaxed"
+          style={{
+            opacity: hintVisible && !allReady && !hasError ? 1 : 0,
+            transition: "opacity 400ms ease",
+          }}
+        >
+          {HINTS[hintIndex]}
+        </p>
       </div>
+
+      <style>{`
+        @keyframes ts-chase {
+          from { stroke-dashoffset: 0; }
+          to   { stroke-dashoffset: -${CIRCUMF.toFixed(1)}; }
+        }
+        @keyframes ts-orbit {
+          from { transform: rotate(0deg); }
+          to   { transform: rotate(360deg); }
+        }
+      `}</style>
     </div>
   );
 }
@@ -264,16 +323,14 @@ function InitItem({
 
 function AnimatedStageRenderer({ ts }: { ts: UseTurtleshellReturn }) {
   const [displayedStage, setDisplayedStage] = useState<WorkflowStage>(ts.currentStage);
-  const [transitioning, setTransitioning] = useState(false);
+  const [transitioning, setTransitioning]   = useState(false);
   const [phase, setPhase] = useState<"idle" | "out" | "in">("idle");
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (ts.currentStage === displayedStage) return;
-
     setPhase("out");
     setTransitioning(true);
-
     timeoutRef.current = setTimeout(() => {
       setDisplayedStage(ts.currentStage);
       setPhase("in");
@@ -282,7 +339,6 @@ function AnimatedStageRenderer({ ts }: { ts: UseTurtleshellReturn }) {
         setTransitioning(false);
       }, 350);
     }, 150);
-
     return () => { if (timeoutRef.current) clearTimeout(timeoutRef.current); };
   }, [ts.currentStage]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/features/analyzer/MorphAnalyzer.tsx
+++ b/src/features/analyzer/MorphAnalyzer.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useTurtleshell, type UseTurtleshellReturn } from "../../hooks/useTurtleShell";
 import { TurtleLogo, TurtleShellBackground, StepIndicator } from "../../components/layout";
-import { StatusIndicator } from "../../components/ui";
 import { type WorkflowStage } from "../../lib/types";
 import {
   DatasetIngestion,
@@ -15,13 +14,32 @@ import {
 
 export function MorphAnalyzer() {
   const ts = useTurtleshell();
+
+  // Stay on the init screen until both systems are ready, then hold for a
+  // brief moment so the user can see the "ready" state before it disappears.
+  const [initializing, setInitializing] = useState(true);
+  const [readyToTransition, setReadyToTransition] = useState(false);
+  const transitionTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (ts.pyodideReady && ts.indexedDBReady && initializing) {
+      // Show the "all ready" state for 600ms before sliding into the app
+      setReadyToTransition(true);
+      transitionTimer.current = setTimeout(() => setInitializing(false), 700);
+    }
+    return () => {
+      if (transitionTimer.current) clearTimeout(transitionTimer.current);
+    };
+  }, [ts.pyodideReady, ts.indexedDBReady, initializing]);
+
   return (
     <div className="min-h-screen flex items-center justify-center p-4 md:p-8 relative">
       <TurtleShellBackground />
 
       <main className="w-full max-w-4xl relative z-10">
         <div className="bg-card/98 backdrop-blur-3xl border border-border/20 rounded-2xl shadow-2xl shadow-black/40 overflow-hidden ring-1 ring-white/5">
-          {/* Header */}
+
+          {/* Header — no status dots, they live in the init screen now */}
           <header className="px-6 py-4 flex items-center justify-between border-b border-border/20 bg-secondary/5">
             <div className="flex items-center gap-4">
               <div className="w-11 h-11 rounded-xl bg-gradient-to-br from-primary/20 to-primary/5 border border-primary/10 flex items-center justify-center">
@@ -41,36 +59,35 @@ export function MorphAnalyzer() {
                 </p>
               </div>
             </div>
-            <div className="flex items-center gap-3">
-              <StatusIndicator label="py" isReady={ts.pyodideReady} />
-              <StatusIndicator label="db" isReady={ts.indexedDBReady} />
-            </div>
           </header>
 
-          {/* Error banners */}
-          {ts.pyodideError && (
-            <ErrorBanner
-              message={`Pyodide failed to load: ${ts.pyodideError}`}
-              hint="Check your connection — Pyodide downloads ~10MB on first run. Private browsing may block required storage."
+          {initializing ? (
+            <InitView
+              pyodideReady={ts.pyodideReady}
+              indexedDBReady={ts.indexedDBReady}
+              pyodideError={ts.pyodideError}
+              allReady={readyToTransition}
             />
-          )}
-          {!ts.indexedDBReady && !ts.pyodideLoading && (
-            <ErrorBanner
-              message="IndexedDB unavailable"
-              hint="Your browser may be blocking storage. Try disabling private/incognito mode, or check site permissions."
-            />
-          )}
+          ) : (
+            <>
+              {/* Error banners — only shown post-init */}
+              {ts.pyodideError && (
+                <ErrorBanner
+                  message={`Pyodide failed to load: ${ts.pyodideError}`}
+                  hint="Check your connection — Pyodide downloads ~10MB on first run. Private browsing may block required storage."
+                />
+              )}
 
-          {/* Step Indicator */}
-          <div className="border-b border-border/20">
-            <StepIndicator
-              currentStage={ts.currentStage}
-              completedStages={ts.completedStages}
-            />
-          </div>
+              <div className="border-b border-border/20">
+                <StepIndicator
+                  currentStage={ts.currentStage}
+                  completedStages={ts.completedStages}
+                />
+              </div>
 
-          {/* Stage Content — animated */}
-          <AnimatedStageRenderer ts={ts} />
+              <AnimatedStageRenderer ts={ts} />
+            </>
+          )}
         </div>
 
         <p className="mt-5 text-center font-mono text-[9px] text-muted-foreground/30 tracking-wider">
@@ -80,6 +97,170 @@ export function MorphAnalyzer() {
     </div>
   );
 }
+
+// ── Initialization screen ────────────────────────────────────────────────────
+
+interface InitViewProps {
+  pyodideReady: boolean;
+  indexedDBReady: boolean;
+  pyodideError: string | null;
+  allReady: boolean;
+}
+
+function InitView({ pyodideReady, indexedDBReady, pyodideError, allReady }: InitViewProps) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center px-8 py-16 gap-10 transition-opacity duration-500"
+      style={{ opacity: allReady ? 0 : 1 }}
+    >
+      {/* Animated logo */}
+      <div className="relative flex items-center justify-center">
+        {/* Outer ring — spins until both ready */}
+        <div
+          className={`absolute w-20 h-20 rounded-full border-2 border-t-primary border-r-primary/30 border-b-primary/10 border-l-primary/30 transition-all duration-700 ${
+            allReady ? "border-primary/40 animate-none scale-110" : "animate-spin"
+          }`}
+          style={{ animationDuration: "2s" }}
+        />
+        {/* Inner pulsing circle */}
+        <div
+          className={`w-14 h-14 rounded-2xl bg-gradient-to-br from-primary/20 to-primary/5 border border-primary/15 flex items-center justify-center transition-all duration-500 ${
+            allReady ? "scale-110 border-primary/40 from-primary/30" : "animate-pulse"
+          }`}
+        >
+          <TurtleLogo
+            className={`w-7 h-7 transition-colors duration-500 ${
+              allReady ? "text-primary" : "text-primary/60"
+            }`}
+          />
+        </div>
+      </div>
+
+      {/* Status items */}
+      <div className="flex flex-col gap-3 w-full max-w-xs">
+        <InitItem
+          label="Python Runtime"
+          sublabel="Loading Pyodide + CRF library"
+          isReady={pyodideReady}
+          hasError={!!pyodideError}
+          errorMessage={pyodideError ?? undefined}
+        />
+        <InitItem
+          label="Database"
+          sublabel="Opening IndexedDB storage"
+          isReady={indexedDBReady}
+          hasError={false}
+        />
+      </div>
+
+      {/* Status text */}
+      <p
+        className={`font-mono text-[11px] tracking-wider transition-colors duration-500 ${
+          allReady
+            ? "text-primary/70"
+            : pyodideError
+              ? "text-red-400/70"
+              : "text-muted-foreground/40"
+        }`}
+      >
+        {pyodideError
+          ? "Failed to initialize — see error above"
+          : allReady
+            ? "Ready"
+            : "Initializing…"}
+      </p>
+    </div>
+  );
+}
+
+function InitItem({
+  label,
+  sublabel,
+  isReady,
+  hasError,
+  errorMessage,
+}: {
+  label: string;
+  sublabel: string;
+  isReady: boolean;
+  hasError: boolean;
+  errorMessage?: string;
+}) {
+  return (
+    <div
+      className={`flex items-center gap-4 px-4 py-3.5 rounded-xl border transition-all duration-500 ${
+        hasError
+          ? "border-red-400/20 bg-red-400/5"
+          : isReady
+            ? "border-primary/20 bg-primary/5"
+            : "border-border/10 bg-secondary/5"
+      }`}
+    >
+      {/* State icon */}
+      <div className="shrink-0 w-7 h-7 flex items-center justify-center">
+        {hasError ? (
+          <div className="w-5 h-5 rounded-full bg-red-400/15 flex items-center justify-center">
+            <span className="font-mono text-[10px] text-red-400 leading-none">✕</span>
+          </div>
+        ) : isReady ? (
+          <div className="w-5 h-5 rounded-full bg-primary/15 flex items-center justify-center">
+            {/* Checkmark svg inline — no extra icon import needed */}
+            <svg className="w-3 h-3 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+            </svg>
+          </div>
+        ) : (
+          <svg
+            className="w-5 h-5 text-muted-foreground/30 animate-spin"
+            style={{ animationDuration: "1.2s" }}
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle className="opacity-20" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" />
+            <path
+              className="opacity-70"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+            />
+          </svg>
+        )}
+      </div>
+
+      {/* Label */}
+      <div className="flex-1 min-w-0">
+        <p
+          className={`font-mono text-[12px] font-medium transition-colors duration-500 ${
+            hasError
+              ? "text-red-400"
+              : isReady
+                ? "text-primary"
+                : "text-foreground/60"
+          }`}
+        >
+          {label}
+        </p>
+        <p className="font-mono text-[10px] text-muted-foreground/40 mt-0.5 truncate">
+          {hasError && errorMessage ? errorMessage : sublabel}
+        </p>
+      </div>
+
+      {/* Ready / loading pill */}
+      <div
+        className={`shrink-0 px-2 py-0.5 rounded-md font-mono text-[9px] uppercase tracking-wider transition-all duration-500 ${
+          hasError
+            ? "bg-red-400/10 text-red-400/70"
+            : isReady
+              ? "bg-primary/10 text-primary/70"
+              : "bg-border/10 text-muted-foreground/30"
+        }`}
+      >
+        {hasError ? "error" : isReady ? "ready" : "loading"}
+      </div>
+    </div>
+  );
+}
+
+// ── Animated stage renderer ──────────────────────────────────────────────────
 
 function AnimatedStageRenderer({ ts }: { ts: UseTurtleshellReturn }) {
   const [displayedStage, setDisplayedStage] = useState<WorkflowStage>(ts.currentStage);

--- a/src/features/analyzer/MorphAnalyzer.tsx
+++ b/src/features/analyzer/MorphAnalyzer.tsx
@@ -387,6 +387,7 @@ function StageRenderer({ ts }: { ts: UseTurtleshellReturn }) {
           isUploading={ts.isUploading}
           pyodideReady={ts.pyodideReady}
           onSnapshot={ts.handleDownloadSnapshot}
+          delimiter={ts.modelConfig.delimiter}
         />
       );
     case "training":

--- a/src/features/analyzer/stages/AnnotationWorkspace.tsx
+++ b/src/features/analyzer/stages/AnnotationWorkspace.tsx
@@ -2,32 +2,6 @@ import { useState, useCallback, useRef, useEffect } from "react";
 import type { AnnotationWord } from "../../../lib/types";
 import { ArrowIcon, UploadSmallIcon, CheckAllIcon, SnapshotIcon } from "../../../components/ui/icons";
 
-// ============================================================
-// Annotation Workspace Stage
-// One-word-at-a-time focused annotation interface.
-// Shows a single word card with boundary editing, plus a
-// progress rail and context about why these words were selected.
-//
-// Dev/testing feature: "Load Gold File" parses a gold-standard
-// .tgt file and auto-fills boundaries for matching words so you
-// can blast through annotation cycles during testing.
-// ============================================================
-
-/**
- * Parse a gold .tgt / annotated file into surface-word → boundary indices.
- *
- * Auto-detects the boundary marker by scanning the first 20 non-empty lines
- * and picking whichever of !  +  |  -  _  appears most often.
- * Falls back to treating the whole line as an unsegmented word if none found.
- *
- * Both space-separated char format ("u n ! h a p p y") and compact format
- * ("un!happy") are handled — internal whitespace is stripped before splitting.
- *
- * :returns: { lookup, separator, sampleLines }
- *   lookup      — Map<normalizedWord, boundaryIndices[]>
- *   separator   — the char that was detected (for debug display)
- *   sampleLines — first 3 raw lines (for debug display)
- */
 function parseGoldFile(content: string): {
   lookup: Map<string, number[]>;
   separator: string;
@@ -80,8 +54,8 @@ interface AnnotationWorkspaceProps {
   onSkip: () => void;
   totalWords: number;
   currentIteration: number;
-  totalIterations: number;
   onSnapshot: () => void;
+  onReadSnapshot: (snapshotJson: string) => Promise<void>;
 }
 
 export function AnnotationWorkspaceStage({
@@ -91,8 +65,8 @@ export function AnnotationWorkspaceStage({
   onSkip,
   totalWords,
   currentIteration,
-  totalIterations,
   onSnapshot,
+  onReadSnapshot,
 }: AnnotationWorkspaceProps) {
   const [focusIndex, setFocusIndex] = useState(0);
   const [showSkipConfirm, setShowSkipConfirm] = useState(false);
@@ -100,6 +74,7 @@ export function AnnotationWorkspaceStage({
 
   // Dev/testing: gold file auto-annotation
   const goldInputRef = useRef<HTMLInputElement>(null);
+  const snapshotInputRef = useRef<HTMLInputElement>(null);
   const [goldMatchCount, setGoldMatchCount] = useState<number | null>(null);
   const [goldDebug, setGoldDebug] = useState<{
     separator: string;
@@ -122,9 +97,6 @@ export function AnnotationWorkspaceStage({
   const currentWord = words[focusIndex] ?? null;
   const annotatedCount = annotatedSet.size;
   const allDone = annotatedCount === totalWords && totalWords > 0;
-
-  const isEarlyIteration = currentIteration <= Math.ceil(totalIterations * 0.3);
-  const isLateIteration = currentIteration >= Math.ceil(totalIterations * 0.7);
 
   const handleConfirm = useCallback(() => {
     if (!currentWord) return;
@@ -199,6 +171,20 @@ export function AnnotationWorkspaceStage({
     [onUpdateBoundaries]
   );
 
+  const handleSnapshotUpload = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        onReadSnapshot(reader.result as string);
+      };
+      reader.readAsText(file);
+      e.target.value = "";
+    },
+    [onReadSnapshot]
+  );
+
   /** Confirm all words at once using current boundaries (CRF predictions as-is). */
   const handleConfirmAll = useCallback(() => {
     setAnnotatedSet(new Set(wordsRef.current.map((w) => w.id)));
@@ -223,7 +209,7 @@ export function AnnotationWorkspaceStage({
                 Cycle
               </span>
               <span className="font-mono text-[11px] text-foreground tabular-nums font-medium">
-                {currentIteration}/{totalIterations}
+                {currentIteration}
               </span>
             </div>
           </div>
@@ -237,16 +223,6 @@ export function AnnotationWorkspaceStage({
             <span className="text-primary font-medium">least confident</span>{" "}
             about. Your corrections have the highest impact on accuracy.
           </p>
-          {isEarlyIteration && (
-            <p className="font-mono text-[10px] text-muted-foreground/70 mt-2">
-              Early iteration -- expect more errors as the model learns basic patterns.
-            </p>
-          )}
-          {isLateIteration && (
-            <p className="font-mono text-[10px] text-muted-foreground/70 mt-2">
-              Late iteration -- the model has stabilized. Errors should be fewer and more subtle.
-            </p>
-          )}
         </div>
 
         {/* -- Dev/Testing Tools -- */}
@@ -473,14 +449,34 @@ export function AnnotationWorkspaceStage({
           )}
         </div>
 
-        <button
-          onClick={onSnapshot}
-          className="flex items-center gap-1.5 px-4 py-2 rounded-lg border border-border/40 bg-secondary/10 font-mono text-[11px] text-muted-foreground/70 hover:text-foreground hover:bg-secondary/20 transition-all"
-          title="Download a snapshot of your current work"
-        >
-          <SnapshotIcon />
-          <span>Snapshot</span>
-        </button>
+        <div className="flex items-center gap-2">
+          {/* Restore snapshot */}
+          <input
+            ref={snapshotInputRef}
+            type="file"
+            accept=".json"
+            onChange={handleSnapshotUpload}
+            className="hidden"
+          />
+          <button
+            onClick={() => snapshotInputRef.current?.click()}
+            className="flex items-center gap-1.5 px-4 py-2 rounded-lg border border-border/40 bg-secondary/10 font-mono text-[11px] text-muted-foreground/70 hover:text-foreground hover:bg-secondary/20 transition-all"
+            title="Restore work from a snapshot file"
+          >
+            <UploadSmallIcon />
+            <span>Restore Snapshot</span>
+          </button>
+
+          {/* Save snapshot */}
+          <button
+            onClick={onSnapshot}
+            className="flex items-center gap-1.5 px-4 py-2 rounded-lg border border-border/40 bg-secondary/10 font-mono text-[11px] text-muted-foreground/70 hover:text-foreground hover:bg-secondary/20 transition-all"
+            title="Download a snapshot of your current work"
+          >
+            <SnapshotIcon />
+            <span>Snapshot</span>
+          </button>
+        </div>
 
         <button
           onClick={onSubmit}

--- a/src/features/analyzer/stages/DatasetIngestion.tsx
+++ b/src/features/analyzer/stages/DatasetIngestion.tsx
@@ -209,7 +209,7 @@ function ValidationPanel({
   annotatedFiles,
   unannotatedFiles,
   validationMap,
-  delimiter,
+  // delimiter, TOOD: use delimiter in the future.
 }: {
   annotatedFiles: fileData[];
   unannotatedFiles: fileData[];

--- a/src/features/analyzer/stages/DatasetIngestion.tsx
+++ b/src/features/analyzer/stages/DatasetIngestion.tsx
@@ -1,7 +1,20 @@
-import { useState, type DragEvent, type ChangeEvent } from "react";
+import { useState, useEffect, type DragEvent, type ChangeEvent } from "react";
 import type { fileData, FileRole } from "../../../lib/types";
 import { formatSize } from "../../../lib/format-utils";
-import { UploadIcon, FileIcon, TrashIcon, ArrowIcon, SnapshotIcon } from "../../../components/ui/icons";
+import {
+  UploadIcon, FileIcon, TrashIcon, ArrowIcon, SnapshotIcon,
+} from "../../../components/ui/icons";
+import {
+  validateAnnotatedFile,
+  validateUnannotatedFile,
+  type ValidationResult,
+  MIN_ANNOTATED_LINES,
+} from "../../../lib/validation";
+
+// ============================================================
+// Dataset Ingestion Stage
+// Upload files, assign roles, view validation status
+// ============================================================
 
 interface DatasetIngestionProps {
   files: fileData[];
@@ -13,8 +26,9 @@ interface DatasetIngestionProps {
   isUploading: boolean;
   pyodideReady: boolean;
   onSnapshot: () => void;
+  /** Delimiter from ModelConfig — used to validate annotated files */
+  delimiter: string;
 }
-
 
 export function DatasetIngestion({
   files,
@@ -26,19 +40,83 @@ export function DatasetIngestion({
   isUploading,
   pyodideReady,
   onSnapshot,
+  delimiter,
 }: DatasetIngestionProps) {
-  // Hide internal project files from the user-facing file viewer
   const hiddenNames = new Set(["project.json", "cycles.json", "annotations.json"]);
   const visibleFiles = files.filter((f) => !hiddenNames.has(f.fileName));
-  const annotatedCount = visibleFiles.filter((f) => f.fileRole === "annotated").length;
-  const unannotatedCount = visibleFiles.filter((f) => f.fileRole === "unannotated").length;
-  const hasRequiredFiles = annotatedCount > 0 && unannotatedCount > 0;
+
+  // Validation results keyed by filePath — runs whenever files, roles, or delimiter change
+  const [validationMap, setValidationMap] = useState<Map<string, ValidationResult>>(new Map());
+
+  useEffect(() => {
+    const next = new Map<string, ValidationResult>();
+
+    for (const file of visibleFiles) {
+      if (!file.fileRole || !file.fileContent) {
+        // No role assigned yet or content not loaded — skip
+        continue;
+      }
+
+      const result =
+        file.fileRole === "annotated"
+          ? validateAnnotatedFile(file.fileContent, delimiter)
+          : validateUnannotatedFile(file.fileContent, delimiter);
+
+      next.set(file.filePath, result);
+    }
+
+    setValidationMap(next);
+  }, [files, delimiter]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const annotatedFiles   = visibleFiles.filter((f) => f.fileRole === "annotated");
+  const unannotatedFiles = visibleFiles.filter((f) => f.fileRole === "unannotated");
+  const annotatedCount   = annotatedFiles.length;
+  const unannotatedCount = unannotatedFiles.length;
+
+  // A file blocks training if its validation result is "invalid"
+  const hasBlockingError = (fileList: fileData[]) =>
+    fileList.some((f) => validationMap.get(f.filePath)?.level === "invalid");
+
+  const filesAssigned     = annotatedCount > 0 && unannotatedCount > 0;
+  const annotatedBlocked  = hasBlockingError(annotatedFiles);
+  const unannotatedBlocked = hasBlockingError(unannotatedFiles);
+  const canStartTraining  = filesAssigned && !annotatedBlocked && !unannotatedBlocked;
+
+  // Compose a status message for the footer
+  let statusMessage: { text: string; isError: boolean };
+  if (!filesAssigned) {
+    statusMessage = {
+      text: "Assign at least one annotated and one unannotated file to continue",
+      isError: false,
+    };
+  } else if (annotatedBlocked) {
+    const result = validationMap.get(annotatedFiles[0]?.filePath ?? "");
+    statusMessage = { text: result?.summary ?? "Annotated file has errors", isError: true };
+  } else if (unannotatedBlocked) {
+    const result = validationMap.get(unannotatedFiles[0]?.filePath ?? "");
+    statusMessage = { text: result?.summary ?? "Unannotated file has errors", isError: true };
+  } else {
+    statusMessage = { text: "Ready to proceed", isError: false };
+  }
 
   return (
     <div className="flex flex-col gap-0">
-
-      {/* Upload zone */}
       <UploadZone onUpload={onUpload} isUploading={isUploading} pyodideReady={pyodideReady} />
+
+      {/* Delimiter indicator — visible once files are assigned */}
+      {filesAssigned && (
+        <div className="px-6 py-2 border-b border-border/10 bg-secondary/5 flex items-center gap-2">
+          <span className="font-mono text-[10px] text-muted-foreground/40 uppercase tracking-wider">
+            Delimiter
+          </span>
+          <span className="px-2 py-0.5 rounded bg-primary/10 border border-primary/15 font-mono text-[11px] text-primary/80 font-semibold">
+            {delimiter}
+          </span>
+          <span className="font-mono text-[10px] text-muted-foreground/30">
+            — change in Model Config if wrong
+          </span>
+        </div>
+      )}
 
       {/* Role summary bar */}
       {visibleFiles.length > 0 && (
@@ -48,14 +126,14 @@ export function DatasetIngestion({
             <RoleCount label="Unannotated" count={unannotatedCount} color="text-foreground" />
           </div>
           <span className="font-mono text-[10px] text-muted-foreground/70">
-            {files.length} total
+            {visibleFiles.length} total
           </span>
         </div>
       )}
 
       {/* File list */}
-      <div className="max-h-[320px] overflow-y-auto">
-        {files.length === 0 ? (
+      <div className="max-h-[360px] overflow-y-auto">
+        {visibleFiles.length === 0 ? (
           <EmptyState />
         ) : (
           <div className="divide-y divide-border/10">
@@ -63,6 +141,7 @@ export function DatasetIngestion({
               <FileRow
                 key={file.filePath}
                 file={file}
+                validationResult={validationMap.get(file.filePath) ?? null}
                 onAssignRole={onAssignRole}
                 onRemove={onRemoveFile}
               />
@@ -71,15 +150,30 @@ export function DatasetIngestion({
         )}
       </div>
 
+      {/* Validation detail panel — shows when there are issues */}
+      {filesAssigned && (annotatedBlocked || unannotatedBlocked) && (
+        <ValidationPanel
+          annotatedFiles={annotatedFiles}
+          unannotatedFiles={unannotatedFiles}
+          validationMap={validationMap}
+          delimiter={delimiter}
+        />
+      )}
+
       {/* Footer */}
       <footer className="px-6 py-4 border-t border-border/20 flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <p className="font-mono text-[10px] text-muted-foreground/40 max-w-xs">
-            {hasRequiredFiles
-              ? "Ready to proceed"
-              : "Assign at least one annotated and one unannotated file to continue"}
-          </p>
-        </div>
+        <p
+          className={`font-mono text-[10px] max-w-sm leading-relaxed ${
+            statusMessage.isError
+              ? "text-red-400/70"
+              : canStartTraining
+                ? "text-primary/60"
+                : "text-muted-foreground/40"
+          }`}
+        >
+          {statusMessage.text}
+        </p>
+
         <div className="flex items-center gap-2">
           <button
             onClick={onBack}
@@ -97,7 +191,7 @@ export function DatasetIngestion({
           </button>
           <button
             onClick={onStartTraining}
-            disabled={!hasRequiredFiles}
+            disabled={!canStartTraining}
             className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-primary text-primary-foreground font-mono text-xs font-semibold tracking-wide transition-all hover:bg-primary/90 active:scale-[0.97] disabled:opacity-30 disabled:pointer-events-none"
           >
             <span>Start Training</span>
@@ -109,7 +203,52 @@ export function DatasetIngestion({
   );
 }
 
-// --- Sub-components ---
+// ── Validation detail panel ──────────────────────────────────────────────────
+
+function ValidationPanel({
+  annotatedFiles,
+  unannotatedFiles,
+  validationMap,
+  delimiter,
+}: {
+  annotatedFiles: fileData[];
+  unannotatedFiles: fileData[];
+  validationMap: Map<string, ValidationResult>;
+  delimiter: string;
+}) {
+  const allIssues: string[] = [];
+
+  for (const f of [...annotatedFiles, ...unannotatedFiles]) {
+    const r = validationMap.get(f.filePath);
+    if (r && r.issues.length > 0) {
+      for (const issue of r.issues.slice(0, 3)) {
+        allIssues.push(issue);
+      }
+    }
+  }
+
+  if (allIssues.length === 0) return null;
+
+  return (
+    <div className="mx-6 mb-3 px-4 py-3 rounded-xl bg-red-400/5 border border-red-400/15">
+      <p className="font-mono text-[10px] text-red-400/70 font-semibold uppercase tracking-wider mb-2">
+        Validation issues
+      </p>
+      <ul className="flex flex-col gap-1">
+        {allIssues.map((issue, i) => (
+          <li key={i} className="font-mono text-[11px] text-red-400/60 leading-relaxed">
+            · {issue}
+          </li>
+        ))}
+      </ul>
+      <p className="font-mono text-[10px] text-muted-foreground/30 mt-2">
+        Min annotated examples: {MIN_ANNOTATED_LINES}
+      </p>
+    </div>
+  );
+}
+
+// ── Sub-components ───────────────────────────────────────────────────────────
 
 function UploadZone({
   onUpload,
@@ -133,14 +272,12 @@ function UploadZone({
     setIsDragOver(true);
   };
 
-  const handleDragLeave = () => setIsDragOver(false);
-
   return (
     <section className="px-6 py-5 border-b border-border/20">
       <label
         onDrop={handleDrop}
         onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
+        onDragLeave={() => setIsDragOver(false)}
         className={`group flex items-center gap-5 p-5 border-2 border-dashed rounded-xl cursor-pointer transition-all duration-300 ${
           isDragOver
             ? "border-primary bg-primary/5 scale-[1.01]"
@@ -155,23 +292,17 @@ function UploadZone({
           accept=".tgt,.csv,.txt,.tsv,.json"
           disabled={!pyodideReady}
         />
-
         <div
           className={`w-12 h-12 rounded-xl flex items-center justify-center transition-all duration-300 ${
-            isDragOver
-              ? "bg-primary/20"
-              : "bg-secondary/15 group-hover:bg-primary/10"
+            isDragOver ? "bg-primary/20" : "bg-secondary/15 group-hover:bg-primary/10"
           }`}
         >
           <UploadIcon
             className={`w-6 h-6 transition-colors ${
-              isDragOver
-                ? "text-primary"
-                : "text-muted-foreground/40 group-hover:text-primary/70"
+              isDragOver ? "text-primary" : "text-muted-foreground/40 group-hover:text-primary/70"
             }`}
           />
         </div>
-
         <div className="flex-1">
           <p className="font-mono text-sm font-medium text-foreground">
             {isUploading ? "Uploading..." : "Add dataset files"}
@@ -180,7 +311,6 @@ function UploadZone({
             Drag and drop or click to browse
           </p>
         </div>
-
         <div className="hidden sm:flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-secondary/10 text-muted-foreground/70 font-mono text-[10px] uppercase tracking-wider">
           <span>.tgt</span>
           <span className="text-border/50">|</span>
@@ -197,10 +327,12 @@ function UploadZone({
 
 function FileRow({
   file,
+  validationResult,
   onAssignRole,
   onRemove,
 }: {
   file: fileData;
+  validationResult: ValidationResult | null;
   onAssignRole: (filePath: string, role: FileRole) => void;
   onRemove: (filePath: string) => void;
 }) {
@@ -215,14 +347,20 @@ function FileRow({
         </span>
       </div>
 
-      {/* File name + size */}
+      {/* File name + size + validation */}
       <div className="flex-1 min-w-0">
         <p className="font-mono text-sm text-foreground truncate">{file.fileName}</p>
         <div className="flex items-center gap-2 mt-0.5">
           <span className="font-mono text-[10px] text-muted-foreground/40">
             {formatSize(file.fileSize)}
           </span>
-          <ValidationBadge status={file.validationStatus} />
+          {validationResult ? (
+            <ValidationBadge result={validationResult} />
+          ) : (
+            <span className="font-mono text-[9px] text-muted-foreground/25 uppercase tracking-wider">
+              {file.fileRole ? "validating..." : "assign role to validate"}
+            </span>
+          )}
         </div>
       </div>
 
@@ -251,16 +389,25 @@ function FileRow({
   );
 }
 
-function ValidationBadge({ status }: { status: string }) {
-  const styles = {
+function ValidationBadge({ result }: { result: ValidationResult }) {
+  const styles: Record<string, string> = {
+    valid:   "text-primary/70",
+    warning: "text-amber-400/70",
+    invalid: "text-red-400/70",
     pending: "text-muted-foreground/30",
-    valid: "text-primary",
-    invalid: "text-red-400",
+  };
+
+  const icons: Record<string, string> = {
+    valid:   "✓",
+    warning: "⚠",
+    invalid: "✕",
+    pending: "·",
   };
 
   return (
-    <span className={`font-mono text-[9px] uppercase tracking-wider ${styles[status as keyof typeof styles] || styles.pending}`}>
-      {status}
+    <span className={`flex items-center gap-1 font-mono text-[9px] uppercase tracking-wider ${styles[result.level]}`}>
+      <span>{icons[result.level]}</span>
+      <span>{result.summary}</span>
     </span>
   );
 }
@@ -279,9 +426,7 @@ function RoleCount({
       <span className={`font-mono text-xs font-semibold tabular-nums ${color}`}>
         {count}
       </span>
-      <span className="font-mono text-[10px] text-muted-foreground/70">
-        {label}
-      </span>
+      <span className="font-mono text-[10px] text-muted-foreground/70">{label}</span>
     </div>
   );
 }
@@ -292,9 +437,7 @@ function EmptyState() {
       <div className="w-16 h-16 rounded-2xl bg-secondary/10 border border-border/10 flex items-center justify-center mx-auto mb-4">
         <FileIcon className="w-7 h-7 text-muted-foreground/15" />
       </div>
-      <p className="font-mono text-sm text-muted-foreground/70 font-medium">
-        No files yet
-      </p>
+      <p className="font-mono text-sm text-muted-foreground/70 font-medium">No files yet</p>
       <p className="font-mono text-[11px] text-muted-foreground/70 mt-1">
         Upload your dataset files to get started
       </p>

--- a/src/features/analyzer/stages/DatasetIngestion.tsx
+++ b/src/features/analyzer/stages/DatasetIngestion.tsx
@@ -3,12 +3,6 @@ import type { fileData, FileRole } from "../../../lib/types";
 import { formatSize } from "../../../lib/format-utils";
 import { UploadIcon, FileIcon, TrashIcon, ArrowIcon, SnapshotIcon } from "../../../components/ui/icons";
 
-// ============================================================
-// Dataset Ingestion Stage
-// Upload files, assign roles, view validation status
-// ============================================================
-
-
 interface DatasetIngestionProps {
   files: fileData[];
   onUpload: (fileList: FileList | null) => void;
@@ -38,12 +32,10 @@ export function DatasetIngestion({
   const visibleFiles = files.filter((f) => !hiddenNames.has(f.fileName));
   const annotatedCount = visibleFiles.filter((f) => f.fileRole === "annotated").length;
   const unannotatedCount = visibleFiles.filter((f) => f.fileRole === "unannotated").length;
-  const evaluationCount = visibleFiles.filter((f) => f.fileRole === "evaluation").length;
   const hasRequiredFiles = annotatedCount > 0 && unannotatedCount > 0;
 
   return (
     <div className="flex flex-col gap-0">
-
 
       {/* Upload zone */}
       <UploadZone onUpload={onUpload} isUploading={isUploading} pyodideReady={pyodideReady} />
@@ -54,7 +46,6 @@ export function DatasetIngestion({
           <div className="flex items-center gap-4">
             <RoleCount label="Annotated" count={annotatedCount} color="text-primary" />
             <RoleCount label="Unannotated" count={unannotatedCount} color="text-foreground" />
-            <RoleCount label="Evaluation" count={evaluationCount} color="text-muted-foreground" />
           </div>
           <span className="font-mono text-[10px] text-muted-foreground/70">
             {files.length} total
@@ -72,8 +63,8 @@ export function DatasetIngestion({
               <FileRow
                 key={file.filePath}
                 file={file}
-                  onAssignRole={onAssignRole}
-                  onRemove={onRemoveFile}
+                onAssignRole={onAssignRole}
+                onRemove={onRemoveFile}
               />
             ))}
           </div>
@@ -124,7 +115,7 @@ function UploadZone({
   onUpload,
   isUploading,
   pyodideReady,
-  }: {
+}: {
   onUpload: (files: FileList | null) => void;
   isUploading: boolean;
   pyodideReady: boolean;
@@ -213,7 +204,7 @@ function FileRow({
   onAssignRole: (filePath: string, role: FileRole) => void;
   onRemove: (filePath: string) => void;
 }) {
-  const extension = (file.fileName ?? '').split(".").pop()?.toLowerCase() || "";
+  const extension = (file.fileName ?? "").split(".").pop()?.toLowerCase() || "";
 
   return (
     <div className="group flex items-center gap-4 px-6 py-3.5 hover:bg-secondary/5 transition-colors">
@@ -246,7 +237,6 @@ function FileRow({
         </option>
         <option value="annotated" className="bg-card text-foreground">Annotated</option>
         <option value="unannotated" className="bg-card text-foreground">Unannotated</option>
-        <option value="evaluation" className="bg-card text-foreground">Evaluation</option>
       </select>
 
       {/* Remove button */}

--- a/src/features/analyzer/stages/ModelConfig.tsx
+++ b/src/features/analyzer/stages/ModelConfig.tsx
@@ -21,11 +21,13 @@ interface ModelConfigProps {
   onReadSnapshot: (snapshotJson: string) => Promise<void>;
 }
 
-const SEED_MAX = 4_294_967_295; // 2^32 - 1
+const SEED_MAX = 4_294_967_295;
 
 function rollSeed(): number {
   return Math.floor(Math.random() * (SEED_MAX + 1));
 }
+
+const DELIMITER_PRESETS = ["!", "|", "+", "-", "_"] as const;
 
 const STRATEGY_INFO: Record<QueryStrategy, { label: string; description: string }> = {
   uncertainty: {
@@ -79,6 +81,7 @@ export function ModelConfigStage({
   const activeStrategy = STRATEGY_INFO[config.queryStrategy];
   const canStart = config.targetLanguage.trim().length > 0;
   const isRandom = config.randomSeed === null;
+  const delim = config.delimiter || "!";
 
   return (
     <div className="flex flex-col gap-0">
@@ -113,8 +116,71 @@ export function ModelConfigStage({
 
       {/* Config form */}
       <div className="px-6 py-6 flex flex-col gap-7 border-b border-border/20">
-        <div className="grid grid-cols-2 gap-5">
 
+        {/* 1. Delimiter — full width, first */}
+        <div className="flex flex-col gap-2.5">
+          <div className="flex items-center gap-2">
+            <label className="font-mono text-[11px] text-muted-foreground uppercase tracking-wider">
+              Annotated File Delimiter
+            </label>
+            <Tooltip text="The character used to separate morphemes in your annotated training file. Must match exactly what your file uses." />
+          </div>
+
+          <div className="flex items-center gap-2">
+            {/* Preset buttons */}
+            <div className="flex items-center gap-1 p-1 bg-background border border-border/15 rounded-lg">
+              {DELIMITER_PRESETS.map((d) => (
+                <button
+                  key={d}
+                  onClick={() => updateField("delimiter", d)}
+                  className={`w-9 h-9 rounded-md font-mono text-sm font-semibold transition-all ${
+                    delim === d
+                      ? "bg-primary text-primary-foreground shadow-sm"
+                      : "text-muted-foreground/70 hover:text-foreground hover:bg-secondary/10"
+                  }`}
+                >
+                  {d}
+                </button>
+              ))}
+            </div>
+
+            {/* Custom input */}
+            <input
+              type="text"
+              value={delim}
+              maxLength={3}
+              onChange={(e) => {
+                const val = e.target.value;
+                if (val.length <= 3) updateField("delimiter", val);
+              }}
+              className="w-20 bg-card border border-border/20 rounded-lg px-3 py-2 font-mono text-sm text-center text-foreground focus:outline-none focus:ring-1 focus:ring-primary/40 focus:border-primary/40 transition-colors"
+              placeholder="custom"
+            />
+
+            {/* Live example preview */}
+            <div className="flex-1 px-3 py-2 bg-secondary/5 border border-border/10 rounded-lg">
+              <span className="font-mono text-[11px] text-muted-foreground/50">example: </span>
+              <span className="font-mono text-[11px] text-foreground/70">
+                walk{delim}ed
+              </span>
+              <span className="font-mono text-[11px] text-muted-foreground/30 mx-1.5">·</span>
+              <span className="font-mono text-[11px] text-foreground/70">
+                un{delim}happy
+              </span>
+              <span className="font-mono text-[11px] text-muted-foreground/30 mx-1.5">·</span>
+              <span className="font-mono text-[11px] text-foreground/70">
+                mean{delim}ing{delim}less
+              </span>
+            </div>
+          </div>
+
+          <p className="font-mono text-[11px] text-muted-foreground/50">
+            Monomorphemic words without the delimiter are valid
+          </p>
+        </div>
+
+        {/* 2. Increment size + Seed — side by side */}
+        <div className="grid grid-cols-2 gap-5">
           {/* Increment size */}
           <div className="flex flex-col gap-2.5">
             <div className="flex items-center gap-2">
@@ -145,15 +211,13 @@ export function ModelConfigStage({
               </label>
               <Tooltip text="Controls the 80/20 train/test split of your annotated data. Leave empty for a new random split each cycle, or fix a value to reproduce exact results." />
             </div>
-
             <div className="flex items-center gap-1.5">
-              {/* Number input — hidden when random, shown when locked */}
               {isRandom ? (
                 <div className="flex-1 flex items-center gap-2 px-4 py-3 bg-card border border-border/15 rounded-lg">
-                  <span className="font-mono text-[11px] text-muted-foreground/80 uppercase tracking-widest">
+                  <span className="font-mono text-[11px] text-muted-foreground/40 uppercase tracking-widest">
                     Random
                   </span>
-                  <span className="font-mono text-[10px] text-muted-foreground/70">
+                  <span className="font-mono text-[10px] text-muted-foreground/25">
                     · new split each cycle
                   </span>
                 </div>
@@ -178,8 +242,6 @@ export function ModelConfigStage({
                   className="flex-1 bg-card border border-primary/30 rounded-lg px-4 py-3 font-mono text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary/40 focus:border-primary/40 transition-colors"
                 />
               )}
-
-              {/* Dice — roll and lock a seed */}
               <button
                 onClick={() => updateField("randomSeed", rollSeed())}
                 className="p-2.5 rounded-lg border border-border/20 bg-card text-muted-foreground/50 hover:text-foreground hover:border-primary/30 hover:bg-primary/5 transition-all"
@@ -187,8 +249,6 @@ export function ModelConfigStage({
               >
                 <DiceIcon className="w-4 h-4" />
               </button>
-
-              {/* Clear — only visible when locked */}
               {!isRandom && (
                 <button
                   onClick={() => updateField("randomSeed", null)}
@@ -199,14 +259,13 @@ export function ModelConfigStage({
                 </button>
               )}
             </div>
-
             <p className="font-mono text-[11px] text-muted-foreground/50">
               {isRandom ? "Click 🎲 to lock a specific seed" : `Locked · 0 – ${SEED_MAX.toLocaleString()}`}
             </p>
           </div>
         </div>
 
-        {/* Query strategy */}
+        {/* 3. Query strategy — full width, last */}
         <div className="flex flex-col gap-2.5">
           <div className="flex items-center gap-2">
             <label className="font-mono text-[11px] text-muted-foreground uppercase tracking-wider">
@@ -214,7 +273,6 @@ export function ModelConfigStage({
             </label>
             <Tooltip text="The algorithm used to decide which unlabeled samples are most valuable for the human to annotate next." />
           </div>
-
           <div className="flex gap-1 p-1 bg-background border border-border/15 rounded-lg">
             {(Object.keys(STRATEGY_INFO) as QueryStrategy[]).map((strategy) => (
               <button
@@ -230,7 +288,6 @@ export function ModelConfigStage({
               </button>
             ))}
           </div>
-
           <div className="px-3 py-2.5 bg-secondary/5 border border-border/10 rounded-lg">
             <p className="font-mono text-[12px] text-foreground font-medium">
               {activeStrategy.label}

--- a/src/features/analyzer/stages/ModelConfig.tsx
+++ b/src/features/analyzer/stages/ModelConfig.tsx
@@ -5,8 +5,13 @@ declare global {
   }
 }
 import type { ModelConfig, QueryStrategy } from "../../../lib/types";
-import { ArrowIcon, Tooltip, SnapshotIcon, UploadSmallIcon, DiceIcon} from "../../../components/ui";
+import { ArrowIcon, Tooltip, SnapshotIcon, UploadSmallIcon, DiceIcon } from "../../../components/ui";
 import { useEffect, useRef } from "react";
+
+// ============================================================
+// Model Configuration Stage
+// Set active learning parameters before training
+// ============================================================
 
 interface ModelConfigProps {
   config: ModelConfig;
@@ -18,11 +23,10 @@ interface ModelConfigProps {
 
 const SEED_MAX = 4_294_967_295; // 2^32 - 1
 
-function randomSeed(): number {
+function rollSeed(): number {
   return Math.floor(Math.random() * (SEED_MAX + 1));
 }
 
-// Strategy descriptions for tooltips
 const STRATEGY_INFO: Record<QueryStrategy, { label: string; description: string }> = {
   uncertainty: {
     label: "Uncertainty Sampling",
@@ -54,25 +58,18 @@ export function ModelConfigStage({
     const file = e.target.files?.[0];
     if (!file) return;
     const reader = new FileReader();
-    reader.onload = () => {
-      const json = reader.result as string;
-      onReadSnapshot(json);
-    };
+    reader.onload = () => onReadSnapshot(reader.result as string);
     reader.readAsText(file);
     e.target.value = "";
   };
 
-  // Set global language variable on window whenever targetLanguage changes
   useEffect(() => {
     if (typeof window !== "undefined" && config.targetLanguage) {
       window.language = config.targetLanguage;
     }
   }, [config.targetLanguage]);
 
-  const updateField = <K extends keyof ModelConfig>(
-    key: K,
-    value: ModelConfig[K]
-  ) => {
+  const updateField = <K extends keyof ModelConfig>(key: K, value: ModelConfig[K]) => {
     onUpdateConfig({ ...config, [key]: value });
     if (key === "targetLanguage" && typeof window !== "undefined" && typeof value === "string") {
       window.language = value;
@@ -81,7 +78,7 @@ export function ModelConfigStage({
 
   const activeStrategy = STRATEGY_INFO[config.queryStrategy];
   const canStart = config.targetLanguage.trim().length > 0;
-  const isRandomSeed = config.randomSeed === null;
+  const isRandom = config.randomSeed === null;
 
   return (
     <div className="flex flex-col gap-0">
@@ -109,15 +106,15 @@ export function ModelConfigStage({
             value={config.targetLanguage}
             onChange={(e) => updateField("targetLanguage", e.target.value)}
             placeholder="e.g. Swahili, Turkish, Zulu..."
-            className="w-full bg-card border border-border/20 rounded-lg px-4 py-3 font-mono text-sm text-foreground placeholder:text-foreground/70 focus:outline-none focus:ring-1 focus:ring-primary/40 focus:border-primary/40 transition-colors"
+            className="w-full bg-card border border-border/20 rounded-lg px-4 py-3 font-mono text-sm text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:ring-1 focus:ring-primary/40 focus:border-primary/40 transition-colors"
           />
         </fieldset>
       </div>
 
       {/* Config form */}
       <div className="px-6 py-6 flex flex-col gap-7 border-b border-border/20">
-        {/* Two-column row: increment size + seed */}
         <div className="grid grid-cols-2 gap-5">
+
           {/* Increment size */}
           <div className="flex flex-col gap-2.5">
             <div className="flex items-center gap-2">
@@ -146,72 +143,70 @@ export function ModelConfigStage({
               <label className="font-mono text-[11px] text-muted-foreground uppercase tracking-wider">
                 Seed
               </label>
-              <Tooltip text="Controls the train/test split of your annotated data. Leave as random for most use cases. Fix a value to reproduce the exact same split across runs." />
+              <Tooltip text="Controls the 80/20 train/test split of your annotated data. Leave empty for a new random split each cycle, or fix a value to reproduce exact results." />
             </div>
 
-            {/* Input row with action buttons */}
             <div className="flex items-center gap-1.5">
-              <div className="relative flex-1">
+              {/* Number input — hidden when random, shown when locked */}
+              {isRandom ? (
+                <div className="flex-1 flex items-center gap-2 px-4 py-3 bg-card border border-border/15 rounded-lg">
+                  <span className="font-mono text-[11px] text-muted-foreground/80 uppercase tracking-widest">
+                    Random
+                  </span>
+                  <span className="font-mono text-[10px] text-muted-foreground/70">
+                    · new split each cycle
+                  </span>
+                </div>
+              ) : (
                 <input
-                  type={isRandomSeed ? "text" : "number"}
-                  value={isRandomSeed ? "" : config.randomSeed!}
+                  type="number"
+                  value={config.randomSeed!}
                   onChange={(e) => {
                     const raw = e.target.value;
                     if (raw === "") {
                       updateField("randomSeed", null);
                     } else {
-                      const n = Math.min(SEED_MAX, Math.max(0, Math.trunc(Number(raw))));
-                      updateField("randomSeed", n);
+                      updateField(
+                        "randomSeed",
+                        Math.min(SEED_MAX, Math.max(0, Math.trunc(Number(raw))))
+                      );
                     }
                   }}
-                  placeholder="random"
                   min={0}
                   max={SEED_MAX}
                   step={1}
-                  className={`w-full bg-card border rounded-lg px-4 py-3 font-mono text-sm focus:outline-none focus:ring-1 focus:ring-primary/40 focus:border-primary/40 transition-colors ${
-                    isRandomSeed
-                      ? "border-border/15 text-muted-foreground/40 placeholder:text-muted-foreground/40 italic"
-                      : "border-border/20 text-foreground"
-                  }`}
+                  className="flex-1 bg-card border border-primary/30 rounded-lg px-4 py-3 font-mono text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary/40 focus:border-primary/40 transition-colors"
                 />
-                {/* "random" badge overlay when no seed is set */}
-                {isRandomSeed && (
-                  <div className="absolute inset-y-0 left-4 flex items-center pointer-events-none">
-                    <span className="font-mono text-[10px] text-muted-foreground/40 uppercase tracking-widest italic">
-                      random
-                    </span>
-                  </div>
-                )}
-              </div>
+              )}
 
-              {/* Roll a random seed and lock it */}
+              {/* Dice — roll and lock a seed */}
               <button
-                onClick={() => updateField("randomSeed", randomSeed())}
+                onClick={() => updateField("randomSeed", rollSeed())}
                 className="p-2.5 rounded-lg border border-border/20 bg-card text-muted-foreground/50 hover:text-foreground hover:border-primary/30 hover:bg-primary/5 transition-all"
-                title="Roll a random seed"
+                title="Roll a random seed and lock it"
               >
                 <DiceIcon className="w-4 h-4" />
               </button>
 
-              {/* Clear back to random — only visible when a seed is locked */}
-              {!isRandomSeed && (
+              {/* Clear — only visible when locked */}
+              {!isRandom && (
                 <button
                   onClick={() => updateField("randomSeed", null)}
                   className="p-2.5 rounded-lg border border-border/20 bg-card text-muted-foreground/40 hover:text-red-400 hover:border-red-400/30 hover:bg-red-400/5 transition-all"
-                  title="Clear seed (use random each cycle)"
+                  title="Clear seed — use random each cycle"
                 >
                   <span className="font-mono text-xs leading-none">✕</span>
                 </button>
               )}
             </div>
 
-            <p className="font-mono text-[11px] text-muted-foreground/70">
-              {isRandomSeed ? "New random split each cycle" : "Range: 0 – 4,294,967,295"}
+            <p className="font-mono text-[11px] text-muted-foreground/50">
+              {isRandom ? "Click 🎲 to lock a specific seed" : `Locked · 0 – ${SEED_MAX.toLocaleString()}`}
             </p>
           </div>
         </div>
 
-        {/* Query strategy - full width with description */}
+        {/* Query strategy */}
         <div className="flex flex-col gap-2.5">
           <div className="flex items-center gap-2">
             <label className="font-mono text-[11px] text-muted-foreground uppercase tracking-wider">
@@ -220,7 +215,6 @@ export function ModelConfigStage({
             <Tooltip text="The algorithm used to decide which unlabeled samples are most valuable for the human to annotate next." />
           </div>
 
-          {/* Strategy selector as segmented control */}
           <div className="flex gap-1 p-1 bg-background border border-border/15 rounded-lg">
             {(Object.keys(STRATEGY_INFO) as QueryStrategy[]).map((strategy) => (
               <button
@@ -237,7 +231,6 @@ export function ModelConfigStage({
             ))}
           </div>
 
-          {/* Active strategy description */}
           <div className="px-3 py-2.5 bg-secondary/5 border border-border/10 rounded-lg">
             <p className="font-mono text-[12px] text-foreground font-medium">
               {activeStrategy.label}

--- a/src/features/analyzer/stages/ModelConfig.tsx
+++ b/src/features/analyzer/stages/ModelConfig.tsx
@@ -5,13 +5,8 @@ declare global {
   }
 }
 import type { ModelConfig, QueryStrategy } from "../../../lib/types";
-import { ArrowIcon, Tooltip, SnapshotIcon, UploadSmallIcon } from "../../../components/ui";
+import { ArrowIcon, Tooltip, SnapshotIcon, UploadSmallIcon, DiceIcon} from "../../../components/ui";
 import { useEffect, useRef } from "react";
-
-// ============================================================
-// Model Configuration Stage
-// Set active learning parameters before training
-// ============================================================
 
 interface ModelConfigProps {
   config: ModelConfig;
@@ -21,7 +16,11 @@ interface ModelConfigProps {
   onReadSnapshot: (snapshotJson: string) => Promise<void>;
 }
 
+const SEED_MAX = 4_294_967_295; // 2^32 - 1
 
+function randomSeed(): number {
+  return Math.floor(Math.random() * (SEED_MAX + 1));
+}
 
 // Strategy descriptions for tooltips
 const STRATEGY_INFO: Record<QueryStrategy, { label: string; description: string }> = {
@@ -62,12 +61,14 @@ export function ModelConfigStage({
     reader.readAsText(file);
     e.target.value = "";
   };
+
   // Set global language variable on window whenever targetLanguage changes
   useEffect(() => {
     if (typeof window !== "undefined" && config.targetLanguage) {
       window.language = config.targetLanguage;
     }
   }, [config.targetLanguage]);
+
   const updateField = <K extends keyof ModelConfig>(
     key: K,
     value: ModelConfig[K]
@@ -80,7 +81,7 @@ export function ModelConfigStage({
 
   const activeStrategy = STRATEGY_INFO[config.queryStrategy];
   const canStart = config.targetLanguage.trim().length > 0;
-
+  const isRandomSeed = config.randomSeed === null;
 
   return (
     <div className="flex flex-col gap-0">
@@ -115,7 +116,7 @@ export function ModelConfigStage({
 
       {/* Config form */}
       <div className="px-6 py-6 flex flex-col gap-7 border-b border-border/20">
-        {/* Two-column row for increment + iterations */}
+        {/* Two-column row: increment size + seed */}
         <div className="grid grid-cols-2 gap-5">
           {/* Increment size */}
           <div className="flex flex-col gap-2.5">
@@ -129,10 +130,7 @@ export function ModelConfigStage({
               type="number"
               value={config.incrementSize}
               onChange={(e) =>
-                updateField(
-                  "incrementSize",
-                  Math.max(1, Number(e.target.value))
-                )
+                updateField("incrementSize", Math.max(1, Number(e.target.value)))
               }
               min={1}
               className="w-full bg-card border border-border/20 rounded-lg px-4 py-3 font-mono text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary/40 focus:border-primary/40 transition-colors"
@@ -142,25 +140,73 @@ export function ModelConfigStage({
             </p>
           </div>
 
-          {/* Iterations */}
+          {/* Seed */}
           <div className="flex flex-col gap-2.5">
             <div className="flex items-center gap-2">
               <label className="font-mono text-[11px] text-muted-foreground uppercase tracking-wider">
-                Iterations
+                Seed
               </label>
-              <Tooltip text="Total number of annotation cycles. After each cycle the model retrains and selects new uncertain samples." />
+              <Tooltip text="Controls the train/test split of your annotated data. Leave as random for most use cases. Fix a value to reproduce the exact same split across runs." />
             </div>
-            <input
-              type="number"
-              value={config.iterations}
-              onChange={(e) =>
-                updateField("iterations", Math.max(1, Number(e.target.value)))
-              }
-              min={1}
-              className="w-full bg-card border border-border/20 rounded-lg px-4 py-3 font-mono text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary/40 focus:border-primary/40 transition-colors"
-            />
+
+            {/* Input row with action buttons */}
+            <div className="flex items-center gap-1.5">
+              <div className="relative flex-1">
+                <input
+                  type={isRandomSeed ? "text" : "number"}
+                  value={isRandomSeed ? "" : config.randomSeed!}
+                  onChange={(e) => {
+                    const raw = e.target.value;
+                    if (raw === "") {
+                      updateField("randomSeed", null);
+                    } else {
+                      const n = Math.min(SEED_MAX, Math.max(0, Math.trunc(Number(raw))));
+                      updateField("randomSeed", n);
+                    }
+                  }}
+                  placeholder="random"
+                  min={0}
+                  max={SEED_MAX}
+                  step={1}
+                  className={`w-full bg-card border rounded-lg px-4 py-3 font-mono text-sm focus:outline-none focus:ring-1 focus:ring-primary/40 focus:border-primary/40 transition-colors ${
+                    isRandomSeed
+                      ? "border-border/15 text-muted-foreground/40 placeholder:text-muted-foreground/40 italic"
+                      : "border-border/20 text-foreground"
+                  }`}
+                />
+                {/* "random" badge overlay when no seed is set */}
+                {isRandomSeed && (
+                  <div className="absolute inset-y-0 left-4 flex items-center pointer-events-none">
+                    <span className="font-mono text-[10px] text-muted-foreground/40 uppercase tracking-widest italic">
+                      random
+                    </span>
+                  </div>
+                )}
+              </div>
+
+              {/* Roll a random seed and lock it */}
+              <button
+                onClick={() => updateField("randomSeed", randomSeed())}
+                className="p-2.5 rounded-lg border border-border/20 bg-card text-muted-foreground/50 hover:text-foreground hover:border-primary/30 hover:bg-primary/5 transition-all"
+                title="Roll a random seed"
+              >
+                <DiceIcon className="w-4 h-4" />
+              </button>
+
+              {/* Clear back to random — only visible when a seed is locked */}
+              {!isRandomSeed && (
+                <button
+                  onClick={() => updateField("randomSeed", null)}
+                  className="p-2.5 rounded-lg border border-border/20 bg-card text-muted-foreground/40 hover:text-red-400 hover:border-red-400/30 hover:bg-red-400/5 transition-all"
+                  title="Clear seed (use random each cycle)"
+                >
+                  <span className="font-mono text-xs leading-none">✕</span>
+                </button>
+              )}
+            </div>
+
             <p className="font-mono text-[11px] text-muted-foreground/70">
-              Train-annotate-retrain rounds
+              {isRandomSeed ? "New random split each cycle" : "Range: 0 – 4,294,967,295"}
             </p>
           </div>
         </div>
@@ -176,21 +222,19 @@ export function ModelConfigStage({
 
           {/* Strategy selector as segmented control */}
           <div className="flex gap-1 p-1 bg-background border border-border/15 rounded-lg">
-            {(Object.keys(STRATEGY_INFO) as QueryStrategy[]).map(
-              (strategy) => (
-                <button
-                  key={strategy}
-                  onClick={() => updateField("queryStrategy", strategy)}
-                  className={`flex-1 px-3 py-2.5 rounded-md font-mono text-[12px] transition-all ${
-                    config.queryStrategy === strategy
-                      ? "bg-primary text-primary-foreground font-semibold shadow-sm"
-                      : "text-muted-foreground/70 hover:text-foreground hover:bg-secondary/10"
-                  }`}
-                >
-                  {STRATEGY_INFO[strategy].label.split(" ")[0]}
-                </button>
-              )
-            )}
+            {(Object.keys(STRATEGY_INFO) as QueryStrategy[]).map((strategy) => (
+              <button
+                key={strategy}
+                onClick={() => updateField("queryStrategy", strategy)}
+                className={`flex-1 px-3 py-2.5 rounded-md font-mono text-[12px] transition-all ${
+                  config.queryStrategy === strategy
+                    ? "bg-primary text-primary-foreground font-semibold shadow-sm"
+                    : "text-muted-foreground/70 hover:text-foreground hover:bg-secondary/10"
+                }`}
+              >
+                {STRATEGY_INFO[strategy].label.split(" ")[0]}
+              </button>
+            ))}
           </div>
 
           {/* Active strategy description */}

--- a/src/features/analyzer/stages/TrainingProgress.tsx
+++ b/src/features/analyzer/stages/TrainingProgress.tsx
@@ -2,14 +2,9 @@ import { useEffect } from "react";
 import type { TrainingStep } from "../../../lib/types";
 import { ArrowIcon, CheckIcon, SnapshotIcon } from "../../../components/ui/icons";
 
-// ============================================================
-// Training Progress Stage
-// ============================================================
-
 interface TrainingProgressProps {
   steps: TrainingStep[];
   currentIteration: number;
-  totalIterations: number;
   isComplete: boolean;
   onContinue: () => void;
   onSnapshot: () => void;
@@ -18,7 +13,6 @@ interface TrainingProgressProps {
 export function TrainingProgressStage({
   steps,
   currentIteration,
-  totalIterations,
   isComplete,
   onContinue,
   onSnapshot,
@@ -41,14 +35,13 @@ export function TrainingProgressStage({
       progressUnits,
       pct: Number(pct.toFixed(2)),
       currentIteration,
-      totalIterations,
       isComplete,
     });
-  }, [steps, completedCount, activeIndex, progressUnits, pct, currentIteration, totalIterations, isComplete]);
+  }, [steps, completedCount, activeIndex, progressUnits, pct, currentIteration, isComplete]);
 
   return (
     <div className="flex flex-col">
-      {/* ---- Header group: title + iteration + summary ---- */}
+      {/* ---- Header group: title + cycle + summary ---- */}
       <div className="px-6 pt-6 pb-4">
         <div className="flex items-start justify-between">
           <div>
@@ -62,24 +55,13 @@ export function TrainingProgressStage({
             )}
           </div>
 
-          {/* Iteration context -- segmented indicator */}
-          <div className="flex items-center gap-2">
-            <div className="flex gap-1">
-              {Array.from({ length: totalIterations }).map((_, i) => (
-                <div
-                  key={i}
-                  className={`h-1.5 w-4 rounded-full ${
-                    i < currentIteration
-                      ? "bg-primary/70"
-                      : i === currentIteration - 1
-                        ? "bg-primary"
-                        : "bg-border/20"
-                  }`}
-                />
-              ))}
-            </div>
-            <span className="font-mono text-[10px] text-muted-foreground/70 tabular-nums">
-              {currentIteration}/{totalIterations}
+          {/* Cycle counter */}
+          <div className="px-3 py-1.5 rounded-lg bg-secondary/20 flex items-center gap-2">
+            <span className="font-mono text-[10px] text-muted-foreground/50 uppercase tracking-wider">
+              Cycle
+            </span>
+            <span className="font-mono text-[11px] text-foreground tabular-nums font-medium">
+              {currentIteration}
             </span>
           </div>
         </div>

--- a/src/hooks/useTrainingOrchestrator.ts
+++ b/src/hooks/useTrainingOrchestrator.ts
@@ -1,15 +1,3 @@
-/**
- * useTrainingOrchestrator.ts
- * Location: src/hooks/useTrainingOrchestrator.ts
- *
- * Purpose:
- *   Manages the CRF training cycle lifecycle: starting a cycle, tracking
- *   step progress, collecting results, and running full-corpus inference.
- *   Isolated from the rest of the workflow so new model types or query
- *   strategies can be added without touching annotation or navigation logic.
- *
- */
-
 import { useState, useCallback } from "react";
 import type {
   fileData,
@@ -28,7 +16,58 @@ import { db } from "../lib/db";
 import { log } from "../lib/logger";
 import type { StepProgressCallback } from "./usePyodideWorker";
 
-const logger = log('training');
+const logger = log("training");
+
+// ── Seeded PRNG (mulberry32) ────────────────────────────────────────────────
+// Used so that train/test splits are reproducible given the same seed, and
+// fully random when the user leaves the seed field empty (null → runtime random).
+
+function mulberry32(seed: number) {
+  return () => {
+    seed |= 0;
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Split an annotated .tgt file into train and test partitions.
+ *
+ * @param content     Raw file content, one word per line
+ * @param trainFrac   Fraction to use for training (default 0.8)
+ * @param seed        Seed for the shuffle — same seed always produces the same split
+ * @returns           { trainSplit, testSplit } as .tgt strings
+ *
+ * Degenerate case: if there are fewer than 5 lines the whole file is used for
+ * both train and test rather than producing a useless 1-line test set.
+ */
+function splitAnnotatedFile(
+  content: string,
+  trainFrac: number,
+  seed: number
+): { trainSplit: string; testSplit: string } {
+  const lines = content.split("\n").filter(Boolean);
+  if (lines.length < 5) {
+    logger.warn(`splitAnnotatedFile: only ${lines.length} lines — skipping split, using full file for both train and test`);
+    return { trainSplit: content, testSplit: content };
+  }
+
+  const rand = mulberry32(seed);
+  const shuffled = [...lines];
+  // Fisher-Yates
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+
+  const cutoff = Math.max(1, Math.floor(shuffled.length * trainFrac));
+  return {
+    trainSplit: shuffled.slice(0, cutoff).join("\n"),
+    testSplit: shuffled.slice(cutoff).join("\n"),
+  };
+}
 
 // ── Input dependencies (provided by compositor) ─────────────────────────────
 
@@ -124,8 +163,13 @@ export function useTrainingOrchestrator(deps: TrainingOrchestratorDeps): Trainin
     // remove when model accesses file data directly
     for (const f of files) {
       // Skip known binary artifacts that the UI shouldn't try to decode as text
-      if (f.filePath && (f.filePath.endsWith('.model') || f.fileName?.toLowerCase().endsWith('.whl') || f.fileName?.toLowerCase().endsWith('.wasm'))) {
-        console.debug('[useTrainingOrchestrator] skipping binary artifact during pre-populate', f.filePath);
+      if (
+        f.filePath &&
+        (f.filePath.endsWith(".model") ||
+          f.fileName?.toLowerCase().endsWith(".whl") ||
+          f.fileName?.toLowerCase().endsWith(".wasm"))
+      ) {
+        console.debug("[useTrainingOrchestrator] skipping binary artifact during pre-populate", f.filePath);
         continue;
       }
       if ((!f.fileContent || f.fileContent.length === 0) && f.filePath) {
@@ -133,15 +177,39 @@ export function useTrainingOrchestrator(deps: TrainingOrchestratorDeps): Trainin
           const res = await db.readFile(f.filePath);
           f.fileContent = res.fileContent;
           f.fileType = res.fileType;
-          console.log('[useTrainingOrchestrator] populated file', { filePath: f.filePath, length: f.fileContent?.length, fileType: f.fileType });
+          console.log("[useTrainingOrchestrator] populated file", {
+            filePath: f.filePath,
+            length: f.fileContent?.length,
+            fileType: f.fileType,
+          });
         } catch (err) {
           logger.warn(`readFile failed for ${f.filePath}`, err);
         }
       }
     }
 
-    const trainTgt = getFileContent(files, "annotated");
-    const testTgt = getFileContent(files, "evaluation");
+    const rawAnnotated = getFileContent(files, "annotated");
+
+    // Resolve seed: null means generate a fresh random value for this cycle.
+    // The resolved seed is logged and passed to the worker so results are
+    // traceable even when the user didn't fix a seed.
+    const resolvedSeed: number =
+      modelConfig.randomSeed !== null
+        ? modelConfig.randomSeed
+        : Math.floor(Math.random() * 4_294_967_296);
+
+    const { trainSplit: trainTgt, testSplit: testTgt } = splitAnnotatedFile(
+      rawAnnotated,
+      0.8,
+      resolvedSeed
+    );
+
+    console.debug("[training] seed", {
+      configured: modelConfig.randomSeed,
+      resolved: resolvedSeed,
+      isRandom: modelConfig.randomSeed === null,
+    });
+
     let selectTgt = getFileContent(files, "unannotated");
     // If in-memory unannotated content looks empty or tiny, re-read from DB
     const unannotatedFile = getFileByRole(files, "unannotated");
@@ -149,7 +217,10 @@ export function useTrainingOrchestrator(deps: TrainingOrchestratorDeps): Trainin
       try {
         const res = await db.readFile(unannotatedFile.filePath);
         selectTgt = res.fileContent;
-        console.debug('[useTrainingOrchestrator] refreshed unannotated file from DB', { filePath: unannotatedFile.filePath, length: selectTgt?.length });
+        console.debug("[useTrainingOrchestrator] refreshed unannotated file from DB", {
+          filePath: unannotatedFile.filePath,
+          length: selectTgt?.length,
+        });
       } catch (err) {
         logger.warn(`Failed to refresh unannotated file ${unannotatedFile.filePath}`, err);
       }
@@ -160,11 +231,13 @@ export function useTrainingOrchestrator(deps: TrainingOrchestratorDeps): Trainin
     const trainCount = (trainTgt ?? "").split("\n").filter(Boolean).length;
     const testCount = (testTgt ?? "").split("\n").filter(Boolean).length;
     const selectCount = (selectTgt ?? "").split("\n").filter(Boolean).length;
-    console.debug('[training] file counts', { trainCount, testCount, selectCount });
+    console.debug("[training] file counts", { trainCount, testCount, selectCount });
     if (selectCount === 0) {
-      console.warn('[training] Aborting: unannotated pool is empty');
+      console.warn("[training] Aborting: unannotated pool is empty");
       setTrainingSteps((prev) =>
-        prev.map((s) => (s.id === 'select' ? { ...s, status: 'error', detail: 'Unannotated pool is empty' } : s))
+        prev.map((s) =>
+          s.id === "select" ? { ...s, status: "error", detail: "Unannotated pool is empty" } : s
+        )
       );
       return;
     }
@@ -178,6 +251,7 @@ export function useTrainingOrchestrator(deps: TrainingOrchestratorDeps): Trainin
       maxIterations: CRF_MAX_ITERATIONS,
       delta: CRF_FEATURE_DELTA,
       selectSize: cumulativeSelectSize.current,
+      randomSeed: resolvedSeed,
     };
 
     try {
@@ -186,9 +260,9 @@ export function useTrainingOrchestrator(deps: TrainingOrchestratorDeps): Trainin
       });
 
       // Debug: surface key parts of the cycle result to help diagnose empty increments
-      console.debug('[useTrainingOrchestrator] cycle result summary', {
+      console.debug("[useTrainingOrchestrator] cycle result summary", {
         incrementWordsLen: result.incrementWords?.length ?? 0,
-        incrementContentLen: (result.incrementContent ?? '').length,
+        incrementContentLen: (result.incrementContent ?? "").length,
         residualCount: result.residualCount,
         sentIncrementSize: cycleConfig.incrementSize,
         sentSelectSize: cycleConfig.selectSize,
@@ -204,8 +278,8 @@ export function useTrainingOrchestrator(deps: TrainingOrchestratorDeps): Trainin
       setEvaluationContent(result.evaluationContent ?? "");
 
       const totalWords =
-        (selectTgt ?? '').split("\n").filter(Boolean).length +
-        (trainTgt ?? '').split("\n").filter(Boolean).length;
+        (selectTgt ?? "").split("\n").filter(Boolean).length +
+        (rawAnnotated ?? "").split("\n").filter(Boolean).length;
 
       setPendingCycleResult({
         precision: result.precision,

--- a/src/hooks/useTurtleShell.ts
+++ b/src/hooks/useTurtleShell.ts
@@ -1,30 +1,3 @@
-/**
- * useTurtleShell.ts
- * Location: src/hooks/useTurtleShell.ts
- *
- * Purpose:
- *   Compositor hook for the TurtleShell active learning workflow.
- *   Wires together focused subsystem hooks and owns the cross-cutting
- *   lifecycle logic (cycle transitions, data flow, state restore).
- *
- *   Subsystem hooks:
- *     useProjectDB()            → IndexedDB persistence
- *     usePyodideWorker()        → CRF training/inference via Web Worker
- *     useTrainingOrchestrator() → Training cycle + inference execution
- *     useAnnotationState()      → Word list + boundary editing
- *
- *   Cycle data flow (new order: training → results → annotation):
- *     After training completes, trainingResult is set immediately so the
- *     results page has metrics to display before the user annotates.
- *     After the user submits annotations:
- *       1. Boundary decisions are converted to .tgt lines
- *       2. Those lines are appended to the "annotated" file in IndexedDB
- *       3. The "unannotated" file is replaced with the residual
- *       4. The next cycle auto-starts (training stage)
- *     So cycle N+1 naturally reads a larger training set and smaller pool.
- *
- */
-
 import { useState, useCallback, useRef, useEffect } from "react";
 import {
   type WorkflowStage,
@@ -83,7 +56,6 @@ export interface UseTurtleshellReturn {
   // Training
   trainingSteps: TrainingStep[];
   currentIteration: number;
-  totalIterations: number;
   isTrainingComplete: boolean;
   handleStartTraining: () => Promise<void>;
 
@@ -501,7 +473,6 @@ export function useTurtleshell(): UseTurtleshellReturn {
     // Training
     trainingSteps: training.trainingSteps,
     currentIteration,
-    totalIterations: modelConfig?.iterations ?? DEFAULT_MODEL_CONFIG.iterations,
     isTrainingComplete: training.isTrainingComplete,
     handleStartTraining,
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -54,6 +54,11 @@ export interface ModelConfig {
    */
   randomSeed: number | null;
   queryStrategy: QueryStrategy;
+  /**
+   * Delimiter character used to separate morphemes in annotated files.
+   * Common values: "!" "|" "+" "-"
+   */
+  delimiter: string;
 }
 
 export const DEFAULT_MODEL_CONFIG: ModelConfig = {
@@ -61,6 +66,7 @@ export const DEFAULT_MODEL_CONFIG: ModelConfig = {
   randomSeed: null,
   queryStrategy: "uncertainty",
   targetLanguage: "English",
+  delimiter: "!",
 };
 
 // --- CRF Training Constants ---
@@ -148,8 +154,7 @@ export interface TrainingCycleConfig {
   selectSize: number;
   /**
    * Resolved random seed for this cycle's train/test split.
-   * Always a concrete number by the time it hits the worker —
-   * null from ModelConfig is resolved to a random value before building this config.
+   * Always a concrete number by the time it hits the worker.
    */
   randomSeed: number;
   /** VFS working directory — default '/tmp/turtleshell' */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -26,7 +26,7 @@ export const WORKFLOW_STAGES: {
 
 // --- Files ---
 
-export type FileRole = "annotated" | "unannotated" | "evaluation";
+export type FileRole = "annotated" | "unannotated";
 
 export type ValidationStatus = "pending" | "valid" | "invalid";
 
@@ -48,15 +48,19 @@ export type QueryStrategy = "uncertainty" | "random" | "margin";
 export interface ModelConfig {
   targetLanguage: string;
   incrementSize: number;
-  iterations: number;
+  /**
+   * Random seed for train/test/select splits. Range: [0, 4_294_967_295].
+   * null = generate a fresh random seed each cycle (non-reproducible).
+   */
+  randomSeed: number | null;
   queryStrategy: QueryStrategy;
 }
 
 export const DEFAULT_MODEL_CONFIG: ModelConfig = {
   incrementSize: 100,
-  iterations: 5,
+  randomSeed: null,
   queryStrategy: "uncertainty",
-  targetLanguage: "English"
+  targetLanguage: "English",
 };
 
 // --- CRF Training Constants ---
@@ -126,9 +130,9 @@ export interface CycleSnapshot {
  * File content is passed as raw strings so Python can write them to VFS.
  */
 export interface TrainingCycleConfig {
-  /** Content of the annotated training .tgt file */
+  /** Content of the annotated training .tgt file (80% split) */
   trainTgt: string;
-  /** Content of the evaluation .tgt file */
+  /** Content of the evaluation .tgt file (20% split of annotated) */
   testTgt: string;
   /** Content of the unannotated pool .tgt file (predicted morphemes) */
   selectTgt: string;
@@ -142,6 +146,12 @@ export interface TrainingCycleConfig {
   delta: number;
   /** Cumulative words selected in prior cycles (0 on first run) */
   selectSize: number;
+  /**
+   * Resolved random seed for this cycle's train/test split.
+   * Always a concrete number by the time it hits the worker —
+   * null from ModelConfig is resolved to a random value before building this config.
+   */
+  randomSeed: number;
   /** VFS working directory — default '/tmp/turtleshell' */
   workDir?: string;
 }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,252 @@
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type ValidationLevel = "pending" | "valid" | "warning" | "invalid";
+
+export interface ValidationResult {
+  level: ValidationLevel;
+  /** Short summary shown in the file row: "423 words" or "Too few examples" */
+  summary: string;
+  /** Specific problems found — shown as a list under the summary */
+  issues: string[];
+  lineCount: number;
+  /** Only set for annotated files — delimiter detected from content */
+  detectedDelimiter?: string;
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * Minimum number of annotated lines required to start training.
+ * TODO: confirm exact threshold with Dr. Liu before finalizing.
+ */
+export const MIN_ANNOTATED_LINES = 10;
+
+/** Delimiters considered when auto-detecting annotated files. */
+const DELIMITER_CANDIDATES = ["!", "|", "+", "-", "_"];
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Normalize a raw file string into trimmed, non-empty lines.
+ * Handles both \n and \r\n (Windows) line endings.
+ */
+function parseLines(content: string): string[] {
+  return content
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+}
+
+/**
+ * Collapse space-separated characters into a compact word.
+ * "p r e a c h e d" → "preached"
+ * "preached"         → "preached"  (no-op for compact format)
+ */
+function collapse(line: string): string {
+  return line.replace(/\s+/g, "");
+}
+
+/**
+ * Detect the most likely delimiter used in a set of lines by counting
+ * occurrences across the first 30 lines.
+ * Returns null if no candidate appears in at least 10% of lines.
+ */
+function detectDelimiter(lines: string[]): string | null {
+  const sample = lines.slice(0, 30);
+  const counts: Record<string, number> = {};
+  for (const c of DELIMITER_CANDIDATES) counts[c] = 0;
+
+  for (const line of sample) {
+    const word = collapse(line);
+    for (const c of DELIMITER_CANDIDATES) {
+      if (word.includes(c)) counts[c]++;
+    }
+  }
+
+  const best = DELIMITER_CANDIDATES.reduce((a, b) => (counts[a] >= counts[b] ? a : b));
+  const rate = counts[best] / sample.length;
+  return rate >= 0.1 ? best : null;
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Validate an unannotated dataset file.
+ *
+ * Rules:
+ *  - Must be non-empty
+ *  - Each line must produce a non-empty word after collapsing spaces
+ *  - Lines should not contain the configured delimiter (wrong file warning)
+ *
+ * @param content   Raw file text
+ * @param delimiter The annotated-file delimiter from config (used to detect swapped files)
+ */
+export function validateUnannotatedFile(
+  content: string,
+  delimiter: string
+): ValidationResult {
+  if (!content || content.trim().length === 0) {
+    return { level: "invalid", summary: "File is empty", issues: [], lineCount: 0 };
+  }
+
+  const lines = parseLines(content);
+
+  if (lines.length === 0) {
+    return { level: "invalid", summary: "File is empty", issues: [], lineCount: 0 };
+  }
+
+  const issues: string[] = [];
+  let delimiterHits = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const word = collapse(lines[i]);
+
+    if (word.length === 0) {
+      // Already filtered by parseLines, defensive guard
+      issues.push(`Line ${i + 1}: empty after collapsing spaces`);
+      continue;
+    }
+
+    if (word.includes(delimiter)) {
+      delimiterHits++;
+    }
+  }
+
+  // If a meaningful portion of lines contain the delimiter, this looks like
+  // an annotated file uploaded in the wrong role slot.
+  const delimiterRate = delimiterHits / lines.length;
+  if (delimiterRate >= 0.3) {
+    issues.push(
+      `${delimiterHits} of ${lines.length} lines contain "${delimiter}" — this looks like an annotated file. Check the role assignment.`
+    );
+    return {
+      level: "invalid",
+      summary: "Looks like an annotated file",
+      issues,
+      lineCount: lines.length,
+    };
+  }
+
+  if (delimiterHits > 0) {
+    issues.push(
+      `${delimiterHits} line${delimiterHits > 1 ? "s" : ""} contain "${delimiter}" — double-check this isn't an annotated file`
+    );
+  }
+
+  return {
+    level: issues.length > 0 ? "warning" : "valid",
+    summary: `${lines.length} word${lines.length !== 1 ? "s" : ""}`,
+    issues,
+    lineCount: lines.length,
+  };
+}
+
+/**
+ * Validate an annotated dataset file.
+ *
+ * Rules:
+ *  - Must be non-empty
+ *  - Must have at least MIN_ANNOTATED_LINES lines
+ *  - Lines with the delimiter must have no empty morpheme segments
+ *    (e.g. "walk!!ed" or "!happy" are invalid)
+ *  - At least one line should contain the delimiter; if none do, warn
+ *    that the delimiter setting may be wrong
+ *  - Auto-detects actual delimiter and warns if it differs from configured
+ *
+ * @param content   Raw file text
+ * @param delimiter The delimiter character configured by the user
+ */
+export function validateAnnotatedFile(
+  content: string,
+  delimiter: string
+): ValidationResult {
+  if (!content || content.trim().length === 0) {
+    return { level: "invalid", summary: "File is empty", issues: [], lineCount: 0 };
+  }
+
+  const lines = parseLines(content);
+
+  if (lines.length === 0) {
+    return { level: "invalid", summary: "File is empty", issues: [], lineCount: 0 };
+  }
+
+  // Minimum dataset size check
+  if (lines.length < MIN_ANNOTATED_LINES) {
+    return {
+      level: "invalid",
+      summary: `Too few examples — need at least ${MIN_ANNOTATED_LINES}`,
+      issues: [
+        `Found ${lines.length} line${lines.length !== 1 ? "s" : ""}, minimum is ${MIN_ANNOTATED_LINES}.`,
+        "Add more annotated words before training.",
+      ],
+      lineCount: lines.length,
+    };
+  }
+
+  const issues: string[] = [];
+  let annotatedCount = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const word = collapse(lines[i]);
+
+    if (!word.includes(delimiter)) {
+      // Monomorphemic word — valid, no delimiter expected
+      continue;
+    }
+
+    annotatedCount++;
+
+    // Split by delimiter and check for empty segments
+    const morphemes = word.split(delimiter);
+    const emptySegments = morphemes.filter((m) => m.length === 0);
+    if (emptySegments.length > 0) {
+      issues.push(
+        `Line ${i + 1}: empty morpheme segment in "${word}" — check for doubled or leading/trailing "${delimiter}"`
+      );
+    }
+  }
+
+  // Detect actual delimiter from content
+  const detected = detectDelimiter(lines);
+  const delimiterRate = annotatedCount / lines.length;
+
+  // If zero lines have the configured delimiter but the file is non-trivial,
+  // the delimiter setting is probably wrong.
+  if (annotatedCount === 0 && lines.length > 5) {
+    const hint = detected
+      ? `Auto-detected "${detected}" as the likely delimiter — update the delimiter setting in Model Config.`
+      : `No lines contain "${delimiter}". If all words are monomorphemic this is fine, otherwise check the delimiter setting.`;
+
+    issues.push(hint);
+
+    return {
+      level: "warning",
+      summary: `${lines.length} words — delimiter "${delimiter}" not found`,
+      issues,
+      lineCount: lines.length,
+      detectedDelimiter: detected ?? undefined,
+    };
+  }
+
+  // Warn if the detected delimiter differs from the configured one
+  if (detected && detected !== delimiter && delimiterRate < 0.05) {
+    issues.push(
+      `Lines mostly use "${detected}" but delimiter is set to "${delimiter}" — results may be incorrect.`
+    );
+  }
+
+  const level = issues.some((iss) => iss.includes("empty morpheme")) ? "invalid"
+    : issues.length > 0 ? "warning"
+    : "valid";
+
+  return {
+    level,
+    summary:
+      annotatedCount > 0
+        ? `${lines.length} words, ${annotatedCount} segmented`
+        : `${lines.length} words (all monomorphemic)`,
+    issues,
+    lineCount: lines.length,
+    detectedDelimiter: detected ?? undefined,
+  };
+}


### PR DESCRIPTION
## What changed

---

### **File upload simplified**
Dropped the three-file system (unannotated, eval_annotated, train_annotated) down to two — unannotated and annotated. The annotated file is split 80/20 internally for train/eval using the seed value. The `FileRole` type no longer includes `"evaluation"`.
### 
**Iterations replaced with Seed**
Removed the Iterations field — each cycle is now independent. Replaced with a Seed input (0–4,294,967,295) that controls the 80/20 train/test split. Empty means a new random seed each cycle. A dice button locks a random value, ✕ clears it. The seed is passed through to the worker via `TrainingCycleConfig`.
### 
**Client-side schema validation**
New `src/lib/validation.ts` validates uploaded files before training can start. Handles space-separated character format (`p r e a c h e d`), compact format, CRLF line endings, monomorphemic words without a delimiter, and multi-boundary words (`mean!ing!less`). Warns if a file looks like it was uploaded in the wrong role slot. Minimum annotated dataset size enforced via `MIN_ANNOTATED_LINES = 10` — exact number to be confirmed with Dr. Liu. Start Training is blocked until files pass validation; warnings allow it through.

### **Annotated file delimiter config**
Added a delimiter field to Model Config with preset buttons (`! | + - _`) and a custom input. A live preview updates as you type. The selected delimiter is passed to validation and shown as a small indicator in the upload stage. Stored in `ModelConfig`, default `"!"`.
### 
**Restore snapshot in annotation stage**
The Restore Snapshot button now appears in the annotation workspace footer, matching what was already available in the config stage.
### 
**Loading screen**
Replaced the py/db status dots in the header with a full-screen initialization overlay. The favicon sits centered with an SVG ring that draws itself around it — indeterminate spinning arc while loading, switches to a determinate fill as each system comes online. Time-based status labels replace raw developer messages. Cycling hints keep the screen from feeling frozen. The app renders underneath the overlay the entire time so there is no blank flash on exit.
### 
**Header cleanup**
Removed the SVG turtle logo from the header across all stages. Header is now text-only.

---

### Files changed
`src/lib/validation.ts` ✦ new · `src/lib/types.ts` · `src/hooks/usePyodideWorker.ts` · `src/hooks/useTrainingOrchestrator.ts` · `src/hooks/useTurtleShell.ts` · `src/features/analyzer/MorphAnalyzer.tsx` · `src/features/analyzer/stages/ModelConfig.tsx` · `src/features/analyzer/stages/DatasetIngestion.tsx` · `src/features/analyzer/stages/TrainingProgress.tsx` · `src/features/analyzer/stages/AnnotationWorkspace.tsx` · `src/components/ui/icons.tsx`