### PR TITLE
Fix getting stuck in training stage

### DIFF
--- a/public/scripts/aliases.py
+++ b/public/scripts/aliases.py
@@ -13,7 +13,6 @@ WordLabels: TypeAlias = list[PredictionLabel]
 DatasetLabels: TypeAlias = list[WordLabels]
 
 ConfidenceData: TypeAlias = tuple[Word, DatasetLabels, float]
-LabeledData: TypeAlias = tuple[Word, DatasetLabels]
 
 CharMarginals: TypeAlias = dict[PredictionLabel, float]
 WordMarginals: TypeAlias = list[CharMarginals]

--- a/public/scripts/format.py
+++ b/public/scripts/format.py
@@ -1,4 +1,4 @@
-from aliases import LabeledData, Word, MorphList, ConfidenceData, DatasetLabels
+from aliases import Word, MorphList, ConfidenceData, DatasetLabels
 
 def format_evaluation(words: list[Word], gold_morphs: list[MorphList], pred_morphs: list[MorphList], 
 					  precision: float, recall: float, f1: float, delimiter: str = '!') -> str:
@@ -14,13 +14,9 @@ def format_evaluation(words: list[Word], gold_morphs: list[MorphList], pred_morp
 		lines.append(f'{word}\t{gold_seg}\t{pred_seg}')
 	return '\n'.join(lines) + '\n'
 	
-def format_increment(confidence_data: list[ConfidenceData | LabeledData]) -> list[dict[str, str | float | list[dict]]]:
+def format_increment(confidence_data: list[ConfidenceData]) -> list[dict[str, str | float | list[dict]]]:
 	increment: list[dict[str, str | float | list[dict]]] = []
 	
-	# Convert LabeledData to ConfidenceData with a default confidence score of 0.0
-	if type(confidence_data[0]) == tuple and len(confidence_data[0]) == 2:
-		confidence_data = [(word, labels, 0.0) for word, labels in confidence_data]
-
 	for i, (word, labels, confscore) in enumerate(confidence_data):
 		increment.append({
 			'id': f'w{i}',

--- a/public/scripts/run.py
+++ b/public/scripts/run.py
@@ -4,6 +4,7 @@
 
 import json, os, random
 from typing import Literal
+from itertools import repeat
 from sklearn_crfsuite import CRF
 
 from aliases import DataDict, DatasetFeatures, DatasetLabels, LabeledData, MorphList, DatasetMarginals, ConfidenceData
@@ -96,11 +97,11 @@ def run_training_cycle(config_json: str) -> str:
 				marginals: DatasetMarginals = crf.predict_marginals(X_select)
 				query_data: list[ConfidenceData] = get_confidence_data(data['select']['words'], y_select_predict, marginals)
 			case 'random':
-				query_data: list[LabeledData] = list(zip(data['select']['words'], y_select_predict))
+				query_data: list[ConfidenceData] = list(zip(data['select']['words'], y_select_predict, repeat(0.0)))
 				random.shuffle(query_data)
 			case _:
 				raise ValueError(f"Unsupported query strategy: {query_strategy}")
-			
+		
 		increment_words: list[str] = [word for word, _, _ in query_data[:increment_size]]
 		increment_content: str = '\n'.join(increment_words)
 		increment_data: list[dict[str, str | float | list[dict]]] = format_increment(query_data[:increment_size])

--- a/public/scripts/run.py
+++ b/public/scripts/run.py
@@ -48,7 +48,7 @@ def run_training_cycle(config_json: str) -> str:
 		annotated_file: str = config['annotatedFile']
 		unannotated_file: str = config['unannotatedFile']
 		target_language: str = config.get('targetLanguage', 'unknown')
-		query_strategy: Literal['confidence', 'random'] = config.get('queryStrategy', 'confidence')
+		query_strategy: Literal['uncertainty', 'random'] = config.get('queryStrategy', 'uncertainty')
 		increment_size: int = config.get('incrementSize', 100)
 		max_iterations: int = config.get('maxIterations', 100)
 		delimiter: str = config.get('delimiter', '!')
@@ -92,11 +92,11 @@ def run_training_cycle(config_json: str) -> str:
 		X_select = get_unlabeled_features(data['select']['words'], delta)
 		y_select_predict: DatasetLabels = crf.predict(X_select)
 		match query_strategy:
-			case 'confidence':
+			case 'uncertainty':
 				marginals: DatasetMarginals = crf.predict_marginals(X_select)
 				query_data: list[ConfidenceData] = get_confidence_data(data['select']['words'], y_select_predict, marginals)
 			case 'random':
-				query_data: LabeledData = list(zip(data['select']['words'], y_select_predict))
+				query_data: list[LabeledData] = list(zip(data['select']['words'], y_select_predict))
 				random.shuffle(query_data)
 			case _:
 				raise ValueError(f"Unsupported query strategy: {query_strategy}")

--- a/public/scripts/run.py
+++ b/public/scripts/run.py
@@ -7,7 +7,7 @@ from typing import Literal
 from itertools import repeat
 from sklearn_crfsuite import CRF
 
-from aliases import DataDict, DatasetFeatures, DatasetLabels, LabeledData, MorphList, DatasetMarginals, ConfidenceData
+from aliases import DataDict, DatasetFeatures, DatasetLabels, MorphList, DatasetMarginals, ConfidenceData
 from partition import process_file
 from db_worker import read_file
 from process_data import process_data

--- a/public/scripts/run.py
+++ b/public/scripts/run.py
@@ -89,10 +89,10 @@ def run_training_cycle(config_json: str) -> str:
 			data['test']['words'], data['test']['morphs'], test_predictions, precision, recall, f1, delimiter
 		)
 
+		X_select = get_unlabeled_features(data['select']['words'], delta)
+		y_select_predict: DatasetLabels = crf.predict(X_select)
 		match query_strategy:
 			case 'confidence':
-				X_select = get_unlabeled_features(data['select']['words'], delta)
-				y_select_predict: DatasetLabels = crf.predict(X_select)
 				marginals: DatasetMarginals = crf.predict_marginals(X_select)
 				query_data: list[ConfidenceData] = get_confidence_data(data['select']['words'], y_select_predict, marginals)
 			case 'random':


### PR DESCRIPTION
To do this, I needed three fixes:
1. Switch from expecting `confidence` to expecting `uncertainty`. Since the Python was expecting `confidence` and was getting passed `uncertainty`, it was erroring out (not sure why we can't see that in the console, but I digress).
2. Move X_select and y_select_predict initializations out of `uncertainty` case. When running the `random` case, which relies on those, those variables were out of scope.
3. Standardize the `query_data` variable to ensure the list comprehension correctly handles the data

Fixes issue #75 